### PR TITLE
Fix pandas_ta bbands function parameters across all controllers

### DIFF
--- a/bots/controllers/directional_trading/bollinger_v1.py
+++ b/bots/controllers/directional_trading/bollinger_v1.py
@@ -70,8 +70,8 @@ class BollingerV1Controller(DirectionalTradingControllerBase):
                                                       interval=self.config.interval,
                                                       max_records=self.max_records)
         # Add indicators
-        df.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
-        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        df.ta.bbands(length=self.config.bb_length, lower_std=self.config.bb_std, upper_std=self.config.bb_std, append=True)
+        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"]
 
         # Generate signal
         long_condition = bbp < self.config.bb_long_threshold

--- a/bots/controllers/directional_trading/bollingrid.py
+++ b/bots/controllers/directional_trading/bollingrid.py
@@ -99,9 +99,9 @@ class BollinGridController(DirectionalTradingControllerBase):
                                                       interval=self.config.interval,
                                                       max_records=self.max_records)
         # Add indicators
-        df.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
-        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
-        bb_width = df[f"BBB_{self.config.bb_length}_{self.config.bb_std}"]
+        df.ta.bbands(length=self.config.bb_length, lower_std=self.config.bb_std, upper_std=self.config.bb_std, append=True)
+        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"]
+        bb_width = df[f"BBB_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"]
 
         # Generate signal
         long_condition = bbp < self.config.bb_long_threshold

--- a/bots/controllers/directional_trading/dman_v3.py
+++ b/bots/controllers/directional_trading/dman_v3.py
@@ -161,11 +161,11 @@ class DManV3Controller(DirectionalTradingControllerBase):
                                                       interval=self.config.interval,
                                                       max_records=self.max_records)
         # Add indicators
-        df.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
+        df.ta.bbands(length=self.config.bb_length, lower_std=self.config.bb_std, upper_std=self.config.bb_std, append=True)
 
         # Generate signal
-        long_condition = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}"] < self.config.bb_long_threshold
-        short_condition = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}"] > self.config.bb_short_threshold
+        long_condition = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"] < self.config.bb_long_threshold
+        short_condition = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"] > self.config.bb_short_threshold
 
         # Generate signal
         df["signal"] = 0

--- a/bots/controllers/directional_trading/dman_v3.py
+++ b/bots/controllers/directional_trading/dman_v3.py
@@ -179,7 +179,7 @@ class DManV3Controller(DirectionalTradingControllerBase):
     def get_spread_multiplier(self) -> Decimal:
         if self.config.dynamic_order_spread:
             df = self.processed_data["features"]
-            bb_width = df[f"BBB_{self.config.bb_length}_{self.config.bb_std}"].iloc[-1]
+            bb_width = df[f"BBB_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"].iloc[-1]
             return Decimal(bb_width / 200)
         else:
             return Decimal("1.0")

--- a/bots/controllers/directional_trading/macd_bb_v1.py
+++ b/bots/controllers/directional_trading/macd_bb_v1.py
@@ -80,10 +80,10 @@ class MACDBBV1Controller(DirectionalTradingControllerBase):
                                                       interval=self.config.interval,
                                                       max_records=self.max_records)
         # Add indicators
-        df.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
+        df.ta.bbands(length=self.config.bb_length, lower_std=self.config.bb_std, upper_std=self.config.bb_std, append=True)
         df.ta.macd(fast=self.config.macd_fast, slow=self.config.macd_slow, signal=self.config.macd_signal, append=True)
 
-        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        bbp = df[f"BBP_{self.config.bb_length}_{self.config.bb_std}_{self.config.bb_std}"]
         macdh = df[f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
         macd = df[f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
 

--- a/bots/controllers/generic/quantum_grid_allocator.py
+++ b/bots/controllers/generic/quantum_grid_allocator.py
@@ -135,8 +135,8 @@ class QuantumGridAllocator(ControllerBase):
             if len(candles) == 0:
                 bb_width = self.config.grid_range
             else:
-                bb = ta.bbands(candles["close"], length=self.config.bb_length, std=self.config.bb_std_dev)
-                bb_width = bb[f"BBB_{self.config.bb_length}_{self.config.bb_std_dev}"].iloc[-1] / 100
+                bb = ta.bbands(candles["close"], length=self.config.bb_length, lower_std=self.config.bb_std_dev, upper_std=self.config.bb_std_dev)
+                bb_width = bb[f"BBB_{self.config.bb_length}_{self.config.bb_std_dev}_{self.config.bb_std_dev}"].iloc[-1] / 100
             self.processed_data[trading_pair] = {
                 "bb_width": bb_width
             }


### PR DESCRIPTION
- Replace incorrect 'std=' parameter with 'lower_std=' and 'upper_std='
- Update BBP column references to use correct format: BBP_{length}_{lower_std}_{upper_std}

Affected files:
- bots/controllers/generic/quantum_grid_allocator.py
- bots/controllers/directional_trading/macd_bb_v1.py
- bots/controllers/directional_trading/bollinger_v1.py
- bots/controllers/directional_trading/dman_v3.py
- bots/controllers/directional_trading/bollingrid.py

This fixes KeyError exceptions when trying to access BBP columns that weren't properly created due to incorrect pandas_ta.bbands() parameters.