### PR TITLE
Add redirect_slashes=False for Mintlify docs compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -301,6 +301,7 @@ app = FastAPI(
     description="API for managing Hummingbot trading instances",
     version=VERSION,
     lifespan=lifespan,
+    redirect_slashes=False,
 )
 
 # Add CORS middleware

--- a/models/trading.py
+++ b/models/trading.py
@@ -1,8 +1,10 @@
-from typing import Dict, List, Optional, Any, Literal
-from pydantic import BaseModel, Field, field_validator
-from decimal import Decimal
 from datetime import datetime
-from hummingbot.core.data_type.common import OrderType, TradeType, PositionAction
+from decimal import Decimal
+from typing import Any, Dict, List, Literal, Optional
+
+from hummingbot.core.data_type.common import OrderType, PositionAction, TradeType
+from pydantic import BaseModel, Field, field_validator
+
 from .pagination import PaginationParams, TimeRangePaginationParams
 
 
@@ -190,7 +192,7 @@ class PortfolioStateFilterRequest(BaseModel):
     account_names: Optional[List[str]] = Field(default=None, description="List of account names to filter by")
     connector_names: Optional[List[str]] = Field(default=None, description="List of connector names to filter by")
     skip_gateway: bool = Field(default=False, description="Skip Gateway wallet balance updates for faster CEX-only queries")
-    refresh: bool = Field(default=False, description="If True, refresh balances before returning. If False, return cached state")
+    refresh: bool = Field(default=False, description="If True, refresh balances from exchanges. If False, return cached state.")
 
 
 class PortfolioHistoryFilterRequest(TimeRangePaginationParams):

--- a/routers/portfolio.py
+++ b/routers/portfolio.py
@@ -1,16 +1,12 @@
-from typing import Dict, List, Optional
 from datetime import datetime
+from typing import Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
-from models.trading import (
-    PortfolioStateFilterRequest,
-    PortfolioHistoryFilterRequest,
-    PortfolioDistributionFilterRequest,
-)
-from services.accounts_service import AccountsService
 from deps import get_accounts_service
 from models import PaginatedResponse
+from models.trading import PortfolioDistributionFilterRequest, PortfolioHistoryFilterRequest, PortfolioStateFilterRequest
+from services.accounts_service import AccountsService
 
 router = APIRouter(tags=["Portfolio"], prefix="/portfolio")
 
@@ -28,7 +24,7 @@ async def get_portfolio_state(
             - account_names: Optional list of account names to filter by
             - connector_names: Optional list of connector names to filter by
             - skip_gateway: If True, skip Gateway wallet balance updates for faster CEX-only queries
-            - refresh: If True, refresh balances before returning. If False (default), return cached state
+            - refresh: If True, refresh balances from exchanges. If False, return cached state.
 
     Returns:
         Dict containing account states with connector balances and token information

--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -611,7 +611,8 @@ class AccountsService:
                 await self._connector_service._update_connector_state(connector, connector_name, account_name)
             except Exception as e:
                 logger.error(f"Error refreshing {connector_name}, using stale data: {e}")
-        return await self._get_connector_tokens_info(connector, connector_name)
+        # skip_balance_refresh=True since _update_connector_state already called _update_balances
+        return await self._get_connector_tokens_info(connector, connector_name, skip_balance_refresh=True)
 
     async def update_account_state_loop(self):
         """
@@ -818,12 +819,24 @@ class AccountsService:
             else:
                 self.accounts_state[account_name][connector_name] = result
 
-    async def _get_connector_tokens_info(self, connector, connector_name: str) -> List[Dict]:
+    async def _get_connector_tokens_info(self, connector, connector_name: str, skip_balance_refresh: bool = False) -> List[Dict]:
         """Get token info from a connector instance using RateOracle cached prices.
 
-        Tries the RateOracle (instant, in-memory) first for each token.
-        Only falls back to a batch exchange call for tokens the oracle can't price.
+        Fetches fresh balances from the exchange, then tries the RateOracle (instant, in-memory)
+        first for each token price. Only falls back to a batch exchange call for tokens the oracle can't price.
+
+        Args:
+            connector: The connector instance
+            connector_name: Name of the connector
+            skip_balance_refresh: If True, skip fetching fresh balances (use when caller already refreshed)
         """
+        # Fetch fresh balances from the exchange unless caller already did
+        if not skip_balance_refresh and hasattr(connector, '_update_balances'):
+            try:
+                await connector._update_balances()
+            except Exception as e:
+                logger.warning(f"Failed to refresh balances for {connector_name}, using cached data: {e}")
+
         balances = [{"token": key, "units": value} for key, value in connector.get_all_balances().items() if
                     value != Decimal("0") and key not in settings.banned_tokens]
 

--- a/test/test_portfolio_state.py
+++ b/test/test_portfolio_state.py
@@ -1,0 +1,97 @@
+"""
+Tests for Portfolio State refresh behavior.
+
+Run with: pytest test/test_portfolio_state.py -v
+"""
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("hummingbot")
+
+
+class TestPortfolioStateRefresh:
+    """Tests for portfolio state refresh behavior."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_true_calls_update_account_state(self):
+        """refresh=True should call update_account_state."""
+        from models.trading import PortfolioStateFilterRequest
+        from routers.portfolio import get_portfolio_state
+
+        mock_service = MagicMock()
+        mock_service.update_account_state = AsyncMock()
+        mock_service.get_accounts_state.return_value = {}
+
+        request = PortfolioStateFilterRequest(refresh=True)
+        await get_portfolio_state(request, mock_service)
+
+        mock_service.update_account_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_false_does_not_call_update_account_state(self):
+        """refresh=False should NOT call update_account_state."""
+        from models.trading import PortfolioStateFilterRequest
+        from routers.portfolio import get_portfolio_state
+
+        mock_service = MagicMock()
+        mock_service.update_account_state = AsyncMock()
+        mock_service.get_accounts_state.return_value = {}
+
+        request = PortfolioStateFilterRequest(refresh=False)
+        await get_portfolio_state(request, mock_service)
+
+        mock_service.update_account_state.assert_not_called()
+
+
+class TestBalanceRefresh:
+    """Tests for _get_connector_tokens_info balance refresh."""
+
+    @pytest.fixture
+    def accounts_service(self):
+        """Create AccountsService with mocked dependencies."""
+        from services.accounts_service import AccountsService
+
+        service = AccountsService.__new__(AccountsService)
+        service._market_data_service = MagicMock()
+        service._market_data_service.get_rate.return_value = Decimal("1")
+        return service
+
+    @pytest.fixture
+    def mock_connector(self):
+        """Create a mock connector."""
+        connector = MagicMock()
+        connector._update_balances = AsyncMock()
+        connector.get_all_balances.return_value = {"USDT": Decimal("1000")}
+        connector.get_available_balance.return_value = Decimal("1000")
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_calls_update_balances(self, accounts_service, mock_connector):
+        """_get_connector_tokens_info should call _update_balances."""
+        await accounts_service._get_connector_tokens_info(mock_connector, "okx")
+
+        mock_connector._update_balances.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_update_balances_when_requested(self, accounts_service, mock_connector):
+        """skip_balance_refresh=True should skip _update_balances."""
+        await accounts_service._get_connector_tokens_info(
+            mock_connector, "okx", skip_balance_refresh=True
+        )
+
+        mock_connector._update_balances.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_balance_failure_preserves_stale_data(self, accounts_service, mock_connector):
+        """_update_balances failure should preserve stale cached data."""
+        mock_connector._update_balances = AsyncMock(side_effect=Exception("API error"))
+        mock_connector.get_all_balances.return_value = {"USDT": Decimal("500")}
+
+        result = await accounts_service._get_connector_tokens_info(mock_connector, "okx")
+
+        # Should still return data from get_all_balances (stale cache)
+        assert len(result) == 1
+        assert result[0]["token"] == "USDT"
+        assert result[0]["units"] == 500.0


### PR DESCRIPTION
## Summary
- Adds `redirect_slashes=False` to FastAPI configuration to prevent automatic redirects from `/endpoint` to `/endpoint/`
- Required for Mintlify documentation to properly interact with the API
- **fix(portfolio):** `refresh=true` now fetches fresh balances from exchanges (previously only returned cached data)

## Test plan
- [ ] Verify API endpoints work without trailing slashes
- [ ] Confirm Mintlify docs can make API calls successfully
- [ ] Test portfolio state with `refresh=true` returns fresh exchange balances

🤖 Generated with [Claude Code](https://claude.com/claude-code)