### PR TITLE
Rename coinbase_pro to coinbase_advanced_trade

### DIFF
--- a/bots/credentials/master_account/conf_client.yml
+++ b/bots/credentials/master_account/conf_client.yml
@@ -71,7 +71,7 @@ balance_asset_limit:
   ndax: {}
   foxbit: {}
   bitmex_testnet: {}
-  coinbase_pro: {}
+  coinbase_advanced_trade: {}
   bybit: {}
   binance_paper_trade: {}
   bitfinex: {}


### PR DESCRIPTION
Coinbase Pro no longer exists. It has been officially replaced by “Coinbase Advanced Trade API ” inside the main Coinbase app platform.

Current API: Coinbase Advanced Trade API
Version: v3 (REST + WebSocket)
Status: Active, replaces Coinbase Pro completely

Ref: https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/overview