### PR TITLE
fix(pmm_mister): declare candles_config field required by backtest engine

### DIFF
--- a/bots/controllers/generic/pmm_mister.py
+++ b/bots/controllers/generic/pmm_mister.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Tuple, Union
 
 from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
@@ -19,6 +20,7 @@ class PMMisterConfig(ControllerConfigBase):
     """
     controller_type: str = "generic"
     controller_name: str = "pmm_mister"
+    candles_config: List[CandlesConfig] = []
     connector_name: str = Field(default="binance")
     trading_pair: str = Field(default="BTC-USDT")
     portfolio_allocation: Decimal = Field(default=Decimal("0.1"), json_schema_extra={"is_updatable": True})


### PR DESCRIPTION
## Summary

`PMMisterConfig` is missing the `candles_config` field. The backtest engine reads `self.controller.config.candles_config` unconditionally, so `POST /backtesting/run-backtesting` on any `pmm_mister` config fails with:

```
{"error": "'PMMisterConfig' object has no attribute 'candles_config'"}
```

Injecting the field via the request payload is rejected by `extra="forbid"`, so the fix must live on the config class. Every other controller under `bots/controllers/generic/` already declares this field (`pmm.py:23`, `pmm_adjusted.py:23`, `lp_rebalancer.py:26`) — `pmm_mister.py` is the anomaly.

## Change

Two lines: import `CandlesConfig`, add `candles_config: List[CandlesConfig] = []` to `PMMisterConfig`, mirroring `pmm.py:23`.

## Suggestion (happy to adjust on feedback)

Since every generic controller declares this field with an identical empty-default, this is arguably better lifted to `ControllerConfigBase` so subclasses can't forget it — the current pattern is a footgun that this bug demonstrates. I scoped this PR to the minimal fix to keep it easy to merge, but happy to open a follow-up refactoring `ControllerConfigBase` if that approach is preferred.

## Repro (pure Python, no network)

```python
import sys; from pathlib import Path
sys.path.insert(0, str(Path(__file__).resolve().parent))
from bots.controllers.generic.pmm_mister import PMMisterConfig

config = PMMisterConfig(
    id="x", controller_name="pmm_mister", controller_type="generic",
    connector_name="binance", trading_pair="BTC-USDT", total_amount_quote=100,
    buy_spreads=[0.003], sell_spreads=[0.003],
    buy_amounts_pct=[100], sell_amounts_pct=[100],
    target_base_pct=0.5, min_base_pct=0.3, max_base_pct=0.7,
    leverage=1, take_profit=0.001,
    open_order_type="LIMIT_MAKER", take_profit_order_type="LIMIT_MAKER",
    global_stop_loss=0.03, global_take_profit=0.03,
    max_active_executors_by_level=1,
)
print(f"OK: candles_config = {list(config.candles_config)!r}")
```

On `main`: `AttributeError: 'PMMisterConfig' object has no attribute 'candles_config'`. On this branch: `OK: candles_config = []`.

## Test plan

- [x] Repro above fails on `main`, passes on this branch
- [x] `POST /backtesting/run-backtesting` with a real `pmm_mister` config + 44h window returns HTTP 200 on this branch; crashes on `main`
- [x] Existing test suite — did not run locally; relying on CI

## Related

Splits #(fork PR) into two upstream PRs. This PR is the config-schema fix; the companion PR addresses an independent `KeyError` in `should_effectivize_executor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)