### PR TITLE
fix(pmm_mister): use dict.get() for open_order_last_update access

### DIFF
--- a/bots/controllers/generic/pmm_mister.py
+++ b/bots/controllers/generic/pmm_mister.py
@@ -220,7 +220,7 @@ class PMMister(ControllerBase):
     def should_effectivize_executor(self, executor_info, current_time: int) -> bool:
         """Check if a hanging executor should be effectivized"""
         level_id = executor_info.custom_info.get("level_id", "")
-        fill_time = executor_info.custom_info["open_order_last_update"]
+        fill_time = executor_info.custom_info.get("open_order_last_update")
         if not level_id or not fill_time:
             return False
 


### PR DESCRIPTION
## Summary

`PMMister.should_effectivize_executor` reads `executor_info.custom_info["open_order_last_update"]` with indexed access, which raises `KeyError` when the key is absent — making the very next line's `if not fill_time: return False` guard unreachable dead code.

Live execution usually populates the key before this method runs, which hides the bug in production. The backtest's simulated executor lifecycle calls it earlier, surfacing the issue as a crash.

## Change

One line: `executor_info.custom_info["open_order_last_update"]` → `executor_info.custom_info.get("open_order_last_update")`. This matches the pattern already used for the same key at lines ~624, ~1119, and ~1210 in this same file, and makes the `if not fill_time: return False` guard actually reachable.

## Repro (pure Python, no network)

```python
import sys; from pathlib import Path; from types import SimpleNamespace
sys.path.insert(0, str(Path(__file__).resolve().parent))
from bots.controllers.generic.pmm_mister import PMMister

executor_info = SimpleNamespace(custom_info={"level_id": "buy_0"})
should = PMMister.should_effectivize_executor(None, executor_info, 1_700_000_000)
print(f"OK: returned {should}")
```

On `main`: `KeyError: 'open_order_last_update'`. On this branch: `OK: returned False`.

## Test plan

- [x] Repro above fails on `main`, passes on this branch
- [x] `POST /backtesting/run-backtesting` on a real `pmm_mister` config + 44h window returns HTTP 200 on this branch
- [x] Existing test suite — did not run locally; relying on CI

## Related

Splits #(fork PR) into two upstream PRs. This PR is the control-flow fix; the companion PR declares the missing `candles_config` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)