### PR TITLE
fix / correct Gateway connector import, save_pool content-type, and FastAPI redirect_slashes

### DIFF
--- a/main.py
+++ b/main.py
@@ -305,6 +305,7 @@ app = FastAPI(
     description="API for managing Hummingbot trading instances",
     version=VERSION,
     lifespan=lifespan,
+    redirect_slashes=False,
 )
 
 # Add CORS middleware

--- a/services/gateway_client.py
+++ b/services/gateway_client.py
@@ -353,7 +353,7 @@ class GatewayClient:
         """Save a pool by address using GeckoTerminal lookup"""
         return await self._request("POST", f"pools/save/{address}", params={
             "chainNetwork": chain_network
-        })
+        }, json={})
 
     async def delete_pool(self, chain: str, network: str, address: str) -> Dict:
         """Delete a pool from Gateway's pool list"""

--- a/services/unified_connector_service.py
+++ b/services/unified_connector_service.py
@@ -22,7 +22,7 @@ from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.connector.connector_metrics_collector import TradeVolumeMetricCollector
 from hummingbot.connector.exchange_py_base import ExchangePyBase
-from hummingbot.connector.gateway.gateway_base import GatewayBase as Gateway
+from hummingbot.connector.gateway.gateway import Gateway
 from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState


### PR DESCRIPTION
## Summary

Three small but impactful fixes to the gateway integration layer.

### 1. `services/unified_connector_service.py` — Gateway connector instantiates wrong class

Previously: `from hummingbot.connector.gateway.gateway_base import GatewayBase as Gateway`

The alias made `_create_trading_connector` instantiate `GatewayBase` for every Solana/EVM network connector. `GatewayBase` lacks the CLMM and swap methods that live on the `Gateway` subclass, so **all LP executor operations on Gateway networks fail** with errors like:

```
AttributeError: 'GatewayBase' object has no attribute 'get_pool_info_by_address'
AttributeError: 'GatewayBase' object has no attribute '_clmm_add_liquidity'
```

Fix: import the real `Gateway` subclass. Its `__init__` is `*args, **kwargs` → `super().__init__()`, so the existing `Gateway(connector_name=..., trading_pairs=[], trading_required=True)` call site is unchanged.

### 2. `services/gateway_client.py` — `save_pool` triggers 415 Unsupported Media Type

`save_pool` was the only POST in this client that didn't pass `json=`. Without a JSON body, aiohttp sends no `Content-Type` header, and Fastify on the Gateway side rejects with:

```
{"detail": "Failed to save pool: Unsupported Media Type: application/octet-stream"}
```

This broke `POST /gateway/networks/{network_id}/pools/save/{pool_address}` entirely (the endpoint the Swagger UI fronts directly). Fix: pass `json={}` so aiohttp sets `Content-Type: application/json`.

### 3. `main.py` — disable trailing-slash redirects

Set `redirect_slashes=False` on the FastAPI app. Trailing-slash variants of routes were 307-redirecting, which interferes with Mintlify-driven docs routes that need to resolve cleanly without redirect indirection.

## Test plan

- [ ] Start the API and create an `lp_executor` against a Solana CLMM pool (e.g., Meteora) — verify the executor reaches `OPENING` state and successfully submits `add_liquidity` (previously failed with `AttributeError` on first control-task tick).
- [ ] `POST /gateway/networks/solana-mainnet-beta/pools/save/<known-pool-address>` from the Swagger UI — verify a 200 response with pool data (previously returned 400 with the octet-stream error).
- [ ] Verify trailing-slash routes (e.g., `GET /accounts` vs `GET /accounts/`) no longer 307-redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)