### PR TITLE
Fix available images without image_name

### DIFF
--- a/routers/docker.py
+++ b/routers/docker.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Depends
 
 from models import DockerImage
 from utils.bot_archiver import BotArchiver
+from utils.docker_images import get_image_tags
 from services.docker_service import DockerService
 from deps import get_docker_service, get_bot_archiver
 
@@ -37,9 +38,7 @@ async def available_images(image_name: str = None, docker_service: DockerService
         Dictionary with list of available image tags
     """
     available_images = docker_service.get_available_images()
-    if image_name:
-        return [tag for image in available_images["images"] for tag in image.tags if image_name in tag]
-    return [tag for tag in available_images["images"]]
+    return get_image_tags(available_images["images"], image_name)
 
 
 @router.get("/active-containers")

--- a/test/test_docker_router.py
+++ b/test/test_docker_router.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from utils.docker_images import get_image_tags
+
+
+def test_get_image_tags_without_filter_returns_serializable_tags():
+    result = get_image_tags(
+        [
+            SimpleNamespace(tags=["hummingbot/hummingbot:latest", "hummingbot/hummingbot:dev"]),
+            SimpleNamespace(tags=[]),
+            SimpleNamespace(tags=["hummingbot/gateway:latest"]),
+        ]
+    )
+
+    assert result == [
+        "hummingbot/hummingbot:latest",
+        "hummingbot/hummingbot:dev",
+        "hummingbot/gateway:latest",
+    ]
+
+
+def test_get_image_tags_with_filter_returns_matching_tags():
+    result = get_image_tags(
+        [
+            SimpleNamespace(tags=["hummingbot/hummingbot:latest", "hummingbot/hummingbot:dev"]),
+            SimpleNamespace(tags=[]),
+            SimpleNamespace(tags=["hummingbot/gateway:latest"]),
+        ],
+        image_name="gateway",
+    )
+
+    assert result == ["hummingbot/gateway:latest"]

--- a/utils/docker_images.py
+++ b/utils/docker_images.py
@@ -1,0 +1,5 @@
+def get_image_tags(images, image_name: str = None):
+    image_tags = [tag for image in images for tag in image.tags]
+    if image_name:
+        return [tag for tag in image_tags if image_name in tag]
+    return image_tags


### PR DESCRIPTION
## Description
- flatten Docker images into tag strings for `GET /docker/available-images/` when `image_name` is omitted
- keep the existing filter behavior when `image_name` is provided
- add dependency-light unit coverage for the tag flattening and filtering behavior

Fixes #160

## Testing
- `python3 -m pytest test/test_docker_router.py test/test_portfolio_state.py`
- `git diff --check`

Note: `test/test_portfolio_state.py` is skipped in this checkout because the optional `hummingbot` package is not installed.