### PR TITLE
feat(accounts): fast add-credential with immediate balances + background bring-up

### DIFF
--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -950,10 +950,25 @@ class AccountsService:
             raise HTTPException(status_code=500, detail="Connector service not initialized")
 
         try:
-            # Update the connector keys (this saves the credentials to file and validates them)
-            connector = await self._connector_service.update_connector_keys(account_name, connector_name, credentials)
+            # Saves the credentials to file + fast balances-only validation, and caches the connector
+            # so its balances are available immediately; the full bring-up runs in the background.
+            await self._connector_service.update_connector_keys(account_name, connector_name, credentials)
 
-            await self.update_account_state()
+            # Surface the new connector's balances in the portfolio right away — scoped to just this
+            # connector and skipping Gateway, so it's fast (no all-connectors / unreachable-Gateway
+            # refresh). The full bring-up finishes in the background. A failure here is display-only
+            # and must NOT delete the just-validated credential.
+            try:
+                await self.update_account_state(
+                    account_names=[account_name],
+                    connector_names=[connector_name],
+                    skip_gateway=True,
+                )
+            except Exception as refresh_err:
+                logger.warning(
+                    f"Initial account-state refresh for {connector_name} failed (will refresh on the "
+                    f"next loop): {refresh_err}"
+                )
         except Exception as e:
             logger.error(f"Error adding connector credentials for account {account_name}: {e}")
             await self.delete_credentials(account_name, connector_name)

--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -396,6 +396,11 @@ class MarketDataService:
             max_records=10,
         ))
         try:
+            # Some feeds (e.g. Hyperliquid spot) resolve exchange-specific symbol data in
+            # initialize_exchange_data() that fetch_candles' REST payload depends on; without it
+            # the payload dereferences uninitialized state. get_historical_candles initializes the
+            # same way, so mirror it here in the validation fetch.
+            await feed.initialize_exchange_data()
             end_time = int(_time.time())
             candles = await feed.fetch_candles(end_time=end_time, limit=1)
             if candles is None or len(candles) == 0:

--- a/services/unified_connector_service.py
+++ b/services/unified_connector_service.py
@@ -35,6 +35,9 @@ from utils.security import BackendAPISecurity
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget background connector-init tasks so they aren't GC'd mid-run.
+_BACKGROUND_INIT_TASKS: set = set()
+
 
 class UnifiedConnectorService:
     """
@@ -581,10 +584,27 @@ class UnifiedConnectorService:
         # Authenticate and create connector
         connector = self._create_trading_connector(account_name, connector_name)
 
+        # Fetch balances first (fast, account-level) so the connector is usable for the portfolio
+        # before the heavy bring-up, then finish the rest.
+        await connector._update_balances()
+        await self._finish_trading_connector_init(connector, account_name, connector_name)
+
+        logger.info(f"Initialized trading connector {connector_name} for {account_name}")
+        return connector
+
+    async def _finish_trading_connector_init(
+        self,
+        connector: ConnectorBase,
+        account_name: str,
+        connector_name: str,
+    ) -> None:
+        """Heavy part of trading-connector bring-up: symbol map, trading rules, positions, recorders,
+        metrics, and network tasks. Split out so it can run in the background after a fast
+        balances-only init, upgrading an already-cached connector in place without blocking
+        add-credential or flickering the portfolio."""
         # Initialize symbol map and trading rules
         await connector._initialize_trading_pair_symbol_map()
         await connector._update_trading_rules()
-        await connector._update_balances()
 
         # Perpetual-specific setup
         if self._is_perpetual_connector(connector):
@@ -624,9 +644,6 @@ class UnifiedConnectorService:
                 await connector._update_order_status()
             except Exception as e:
                 logger.error(f"Error updating initial order status for {connector_name}: {e}")
-
-        logger.info(f"Initialized trading connector {connector_name} for {account_name}")
-        return connector
 
     def _create_trading_connector(
         self,
@@ -1061,8 +1078,43 @@ class UnifiedConnectorService:
         # Properly stop old connector (stops recorders, network tasks, cleans up caches)
         await self.stop_trading_connector(account_name, connector_name)
 
-        # Create new connector with fresh recorders
-        return await self.get_trading_connector(account_name, connector_name)
+        # Fast path: create the connector and fetch balances only (mirrors the Hummingbot CLI
+        # `connect`), then CACHE it so the new connector's balances surface in the portfolio
+        # immediately via a scoped update_account_state — instead of blocking ~85s on the full
+        # bring-up (which for Hyperliquid perp fans out a metaAndAssetCtxs call per HIP-3 DEX plus
+        # order-book/websocket startup waits). Bad keys still fail here and the caller deletes the
+        # credential.
+        connector = self._create_trading_connector(account_name, connector_name)
+        await connector._update_balances()
+        self._trading_connectors.setdefault(account_name, {})[connector_name] = connector
+
+        # Finish the heavy bring-up (symbol map, trading rules, HIP-3 markets, network, recorders) in
+        # the background, IN PLACE on the cached connector, so it becomes trade-ready without blocking
+        # the response or flickering the portfolio.
+        task = asyncio.create_task(self._finish_init_background(account_name, connector_name, connector))
+        _BACKGROUND_INIT_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_INIT_TASKS.discard)
+
+        return connector
+
+    async def _finish_init_background(self, account_name: str, connector_name: str, connector: ConnectorBase) -> None:
+        """Finish the heavy trading-connector bring-up in the background, upgrading the already-cached
+        balances-only connector in place so it becomes trade-ready — without blocking add-credential."""
+        try:
+            # Skip if the credential was already removed before this ran.
+            if connector_name not in self.list_available_credentials(account_name):
+                self.clear_trading_connector(account_name, connector_name)
+                return
+            await self._finish_trading_connector_init(connector, account_name, connector_name)
+            # If the credential was deleted WHILE finishing, tear the connector back down so a removed
+            # key doesn't linger in the cache / account state / portfolio.
+            if connector_name not in self.list_available_credentials(account_name):
+                await self.stop_trading_connector(account_name, connector_name)
+                self.clear_trading_connector(account_name, connector_name)
+                return
+            logger.info(f"Background-finished trading connector {connector_name} for {account_name}")
+        except Exception as e:
+            logger.error(f"Background finish failed for {account_name}/{connector_name}: {e}")
 
     def clear_trading_connector(
         self,


### PR DESCRIPTION
## Problem

Adding a connector credential blocks on the **full trading-connector bring-up** before returning. For Hyperliquid perp that is **~85s** — a `metaAndAssetCtxs` call per HIP-3 DEX in *both* symbol-map init and trading-rules update, plus order-book / websocket startup waits. The result:

- the UI sits on "Saving credentials…" for up to a minute, and
- the new connector's balances only appear a refresh loop later (and a full `update_account_state()` over *all* connectors — including an unreachable Gateway — ran on every add).

## Change

Split the trading-connector bring-up into a **fast part** (balances only) and a **heavy part** (the rest), and finish the heavy part in the background.

- **`update_connector_keys`** now creates the connector, fetches **balances only** (mirroring the Hummingbot CLI `connect`), **caches** it, and schedules the heavy bring-up (symbol map, trading rules, HIP-3 markets, positions, recorders, network) in the background — *in place* on the cached connector, so it becomes trade-ready without blocking the response or flickering the portfolio. Bad keys still fail fast here and the caller deletes the credential.
- **`_create_and_initialize_trading_connector`** keeps the exact same end state by calling the new `_finish_trading_connector_init` after the fast balances fetch.
- **`add_credentials`** surfaces the new balances **immediately** via a **scoped** `update_account_state(account_names=[…], connector_names=[…], skip_gateway=True)` instead of a full all-connectors / Gateway refresh. It's wrapped in its own try/except so a *display-only* refresh failure can never delete a just-validated credential.

### Correctness

- **Delete-race guarded:** the background task checks `list_available_credentials` **before and after** finishing, and tears the connector back down if the credential was removed meanwhile — so a removed key can't linger in the cache / account state / portfolio.
- Background tasks are held in a module-level `set` so they aren't garbage-collected mid-run.
- No public API or response-shape changes; the connector reaches the identical fully-initialized state, just asynchronously.

## Result

"Saving credentials" returns in a few seconds and the new balances show up in the portfolio right away; the connector becomes fully trade-ready ~80s later in the background.

## Test plan

1. Add a Hyperliquid (perp + spot) credential via the API → response returns in seconds; balances appear on the next portfolio read.
2. Within the background-finish window, confirm the connector is present with balances; after ~80s confirm it is trade-ready (trading rules / markets loaded).
3. Add a **bad** key → still fails fast and the credential is deleted.
4. Add then immediately delete a credential → it does not reappear after the background finish completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)