### PR TITLE
feat: add default quote currencies for USDC/USD-quoted connectors

### DIFF
--- a/bots/credentials/master_account/conf_client.yml
+++ b/bots/credentials/master_account/conf_client.yml
@@ -112,7 +112,7 @@ anonymized_metrics_mode:
 
 # A source for rate oracle, currently ascend_ex, binance, coin_gecko, coin_cap, kucoin, gate_io
 rate_oracle_source:
-  name: binance
+  name: gate_io
 
 # A universal token which to display tokens values in, e.g. USD,EUR,BTC
 global_token:

--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ async def lifespan(app: FastAPI):
 
         # Get rate_oracle_source configuration
         rate_oracle_source_data = config_data.get("rate_oracle_source", {})
-        source_name = rate_oracle_source_data.get("name", "binance")
+        source_name = rate_oracle_source_data.get("name", "gate_io")
 
         # Get global_token configuration
         global_token_data = config_data.get("global_token", {})
@@ -147,9 +147,9 @@ async def lifespan(app: FastAPI):
             rate_source = create_rate_source(source_name)
             logging.info(f"Configured RateOracle with source: {source_name}, quote_token: {quote_token}")
         else:
-            logging.warning(f"Unknown rate oracle source '{source_name}', defaulting to binance")
-            rate_source = create_rate_source("binance")
-            source_name = "binance"
+            logging.warning(f"Unknown rate oracle source '{source_name}', defaulting to gate_io")
+            rate_source = create_rate_source("gate_io")
+            source_name = "gate_io"
 
         # Initialize RateOracle with configured source and quote token
         rate_oracle = RateOracle.get_instance()
@@ -157,11 +157,15 @@ async def lifespan(app: FastAPI):
         rate_oracle.quote_token = quote_token
 
     except FileNotFoundError:
-        logging.warning("conf_client.yml not found, using default RateOracle configuration (binance, USDT)")
+        logging.warning("conf_client.yml not found, using default RateOracle configuration (gate_io, USDT)")
+        from routers.rate_oracle import create_rate_source
         rate_oracle = RateOracle.get_instance()
+        rate_oracle.source = create_rate_source("gate_io")
     except Exception as e:
-        logging.warning(f"Error reading conf_client.yml: {e}, using default RateOracle configuration")
+        logging.warning(f"Error reading conf_client.yml: {e}, using default RateOracle configuration (gate_io)")
+        from routers.rate_oracle import create_rate_source
         rate_oracle = RateOracle.get_instance()
+        rate_oracle.source = create_rate_source("gate_io")
 
     # =========================================================================
     # 2. UnifiedConnectorService - Single source of truth for all connectors

--- a/models/rate_oracle.py
+++ b/models/rate_oracle.py
@@ -24,7 +24,7 @@ class GlobalTokenConfig(BaseModel):
 class RateOracleSourceConfig(BaseModel):
     """Rate oracle source configuration."""
     name: str = Field(
-        default="binance",
+        default="gate_io",
         description="The rate oracle source to use for price data"
     )
 

--- a/routers/rate_oracle.py
+++ b/routers/rate_oracle.py
@@ -98,7 +98,7 @@ async def get_rate_oracle_config(request: Request):
 
         # Extract rate_oracle_source
         rate_oracle_source_data = config_data.get("rate_oracle_source", {})
-        source_name = rate_oracle_source_data.get("name", "binance")
+        source_name = rate_oracle_source_data.get("name", "gate_io")
 
         # Extract global_token
         global_token_data = config_data.get("global_token", {})
@@ -196,7 +196,7 @@ async def update_rate_oracle_config(
             fs_util.dump_dict_to_yaml(CONF_CLIENT_PATH, config_data)
 
         # Build response
-        current_source = config_data.get("rate_oracle_source", {}).get("name", "binance")
+        current_source = config_data.get("rate_oracle_source", {}).get("name", "gate_io")
         current_global_token = config_data.get("global_token", {})
 
         return RateOracleConfigUpdateResponse(

--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -442,6 +442,18 @@ class AccountsService:
         "hyperliquid_perpetual": "USD",
         "xrpl": "RLUSD",
         "kraken": "USD",
+        "backpack": "USDC",
+        "backpack_perpetual": "USDC",
+        "cube": "USDC",
+        "derive": "USDC",
+        "derive_perpetual": "USDC",
+        "dexalot": "USDC",
+        "vertex": "USDC",
+        "aevo_perpetual": "USDC",
+        "pacifica_perpetual": "USDC",
+        "dydx_v4_perpetual": "USD",
+        "decibel_perpetual": "USD",
+        "architect_perpetual": "USD",
     }
     potential_wrapped_tokens = ["ETH", "SOL", "BNB", "POL", "AVAX"]
     


### PR DESCRIPTION
## Summary

Two fixes for portfolio valuation and rate conversion on fresh / geo-restricted installs.

### 1. Default quote currencies for USDC/USD-quoted connectors

Token balance valuation in `AccountsService` falls back to fetching `TOKEN-<default_quote>` last-traded price from the exchange when the RateOracle has no rate for `TOKEN-USDT`. The global default quote is USDT, which fails on exchanges that don't list USDT pairs — the price resolves to 0 and the token is hidden from portfolio views.

Example: BP holdings on Backpack showed `price: 0.0, value: 0.0` because the fallback requested `BP-USDT`, which doesn't exist on Backpack (it lists `BP-USDC`).

Added `default_quotes` entries, verified against each connector's trading-pair construction in hummingbot:

- **USDC**: backpack, backpack_perpetual, cube, derive, derive_perpetual, dexalot, vertex, aevo_perpetual, pacifica_perpetual (`pacifica_perpetual_web_utils` hardcodes `quote = "USDC"`)
- **USD**: dydx_v4_perpetual, decibel_perpetual, architect_perpetual

Intentionally excluded:
- `grvt_perpetual`, `injective_v2`, `evedex_perpetual` — USDT-quoted in hummingbot (EVEDEX's connector maps its native `-USD` instruments to `-USDT` pairs)
- `btc_markets` (AUD), `ndax` (CAD), `foxbit` (BRL) — the fallback price is consumed as a USD value, so fiat quotes would mis-state portfolio value by the FX rate
- `bybit_perpetual` — `BTC-USD` is the inverse contract; linear markets are USDT

### 2. Default rate oracle source: binance → gate_io

Binance's API returns HTTP 451 from geo-restricted locations (US and others), which silently breaks token valuation and the anonymized-metrics volume conversion on fresh installs — every oracle request fails and tokens are valued at 0. Gate.io is accessible globally and lists the same USDT conversion pairs. Changed the shipped `bots/credentials/master_account/conf_client.yml` template (the always-present explicit value) plus the fallback defaults in `main.py` startup and `routers/rate_oracle.py`; explicit `rate_oracle_source` settings in `conf_client.yml` are unaffected.

## Test plan

- Verified on a live deployment: Backpack BP balance now prices via `BP-USDC` (`price: 0.268, value: $260`) instead of 0, and appears in portfolio views.
- Verified gate_io rate source resolves USDC-USDT from a location where Binance returns 451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
