### PR TITLE
(feat) price Gateway DEX tokens via GeckoTerminal, fall back to Gateway

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - pip
   - pip:
       - hummingbot
+      - geckoterminal-py
       - msgpack>=1.0.5
       - flake8
       - isort

--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -121,7 +121,7 @@ class AccountsService:
         self.gateway_client = GatewayClient(gateway_url, ssl_context_factory=ssl_context_factory)
 
         # Composed services: gateway wallet CRUD/balances, perpetual trading and pure portfolio analytics
-        self.gateway_wallet_service = GatewayWalletService(self.gateway_client)
+        self.gateway_wallet_service = GatewayWalletService(self.gateway_client, market_data_service)
         self.perpetual_trading_service = PerpetualTradingService(self.get_connector_instance)
         self.portfolio_analytics_service = PortfolioAnalyticsService()
 
@@ -138,12 +138,23 @@ class AccountsService:
     def get_accounts_state(self):
         return self.accounts_state
 
-    def get_default_market(self, token: str, connector_name: str) -> str:
+    def _market_components(self, token: str, connector_name: str) -> tuple[str, str]:
+        """Resolve the (base, quote) used to price a token on a connector.
+
+        Unwraps binance-earn staked tokens (LD-prefix) and picks the connector's native quote
+        (e.g. USDC on hyperliquid, USD on hyperliquid_perpetual), falling back to the global
+        default quote. This is the single source of truth for both ticker-pool lookups and the
+        exchange fallback fetch, so they always agree on base and quote.
+        """
         if token.startswith("LD") and token != "LDO":
             # These tokens are staked in binance earn
             token = token[2:]
         quote = self.default_quotes.get(connector_name, self.default_quote)
-        return f"{token}-{quote}"
+        return token, quote
+
+    def get_default_market(self, token: str, connector_name: str) -> str:
+        base, quote = self._market_components(token, connector_name)
+        return f"{base}-{quote}"
 
     def start(self):
         """
@@ -199,6 +210,12 @@ class AccountsService:
                 self._gateway_poller_started = False
             except Exception as e:
                 logger.error(f"Error stopping Gateway transaction poller: {e}", exc_info=True)
+
+        # Close the GeckoTerminal price source HTTP client
+        try:
+            await self.gateway_wallet_service.close()
+        except Exception as e:
+            logger.error(f"Error closing Gateway wallet service: {e}", exc_info=True)
 
         # Stop all connectors through the connector service
         await self._connector_service.stop_all()
@@ -427,10 +444,11 @@ class AccountsService:
                 self.accounts_state[account_name][connector_name] = result
 
     async def _get_connector_tokens_info(self, connector, connector_name: str, skip_balance_refresh: bool = False) -> List[Dict]:
-        """Get token info from a connector instance using RateOracle cached prices.
+        """Get token info from a connector instance using the ticker pool prices.
 
-        Fetches fresh balances from the exchange, then tries the RateOracle (instant, in-memory)
-        first for each token price. Only falls back to a batch exchange call for tokens the oracle can't price.
+        Fetches fresh balances from the exchange, then tries the ticker pool (instant, in-memory
+        cross-rate resolution) first for each token price. Only falls back to a batch exchange
+        call for tokens the pool can't price.
 
         Args:
             connector: The connector instance
@@ -456,13 +474,17 @@ class AccountsService:
             if "USD" in token:
                 price = Decimal("1")
             else:
-                # Try RateOracle first (instant, cached)
-                rate = self._market_data_service.get_rate(token, "USDT")
+                # Price using THIS connector's own tickers and its native quote (instant,
+                # in-memory cross-rate resolution). Using the connector's own quote avoids
+                # mismatches on exchanges that don't list the global quote (e.g. hyperliquid
+                # quotes in USDC/USD, not USDT).
+                base, quote = self._market_components(token, connector_name)
+                rate = self._market_data_service.get_rate_for_connector(connector_name, base, quote)
                 if rate and rate > 0:
                     price = rate
                 else:
                     # Queue for fallback batch fetch from exchange
-                    market = self.get_default_market(token, connector_name)
+                    market = f"{base}-{quote}"
                     missing_pairs.append(market)
                     missing_indices.append(len(tokens_info))
                     price = None  # resolved below

--- a/services/gateway_wallet_service.py
+++ b/services/gateway_wallet_service.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 from fastapi import HTTPException
 
 from services.gateway_client import GatewayClient
+from services.gecko_price_source import GeckoPriceSource
 
 # Create module-specific logger
 logger = logging.getLogger(__name__)
@@ -38,14 +39,23 @@ class GatewayWalletService:
     Gateway manages its own encrypted wallets; this service only talks to it over HTTP via GatewayClient.
     """
 
-    def __init__(self, gateway_client: GatewayClient):
+    def __init__(self, gateway_client: GatewayClient, market_data_service=None):
         """
         Initialize the GatewayWalletService.
 
         Args:
             gateway_client: Client used for all Gateway HTTP interactions.
+            market_data_service: MarketDataService used to publish on-chain DEX prices into the
+                shared price pool so portfolio quoting can resolve blockchain token values.
         """
         self.gateway_client = gateway_client
+        self._market_data_service = market_data_service
+        # Batched DEX price lookups via GeckoTerminal, tried before per-token Gateway quotes.
+        self._gecko_source = GeckoPriceSource(gateway_client)
+
+    async def close(self) -> None:
+        """Release resources held by this service (the GeckoTerminal HTTP client)."""
+        await self._gecko_source.close()
 
     async def _require_gateway(self) -> None:
         """Raise a 503 HTTPException if the Gateway service is not reachable."""
@@ -225,11 +235,14 @@ class GatewayWalletService:
         """
         from hummingbot.core.data_type.common import TradeType
         from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
-        from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 
         gateway_client = GatewayHttpClient.get_instance()
-        rate_oracle = RateOracle.get_instance()
         prices = {}
+
+        def publish_price(trading_pair: str, price: Decimal):
+            """Push an on-chain price into the shared pool so quoting can resolve it later."""
+            if self._market_data_service is not None:
+                self._market_data_service.set_price(trading_pair, price)
 
         # Construct full network name (e.g., "solana-mainnet-beta")
         full_network = f"{chain}-{network}"
@@ -255,14 +268,30 @@ class GatewayWalletService:
                 eth_needs_weth_price = True
                 logger.debug("Removing duplicate ETH, will use WETH price on ethereum")
 
+        # GeckoTerminal first: batch-price the tokens by contract address in a single call set.
+        # Whatever it covers is published here and skipped in the per-token Gateway loop below;
+        # anything it misses (unknown token, no pool, failure) falls back to Gateway pricing.
+        try:
+            gecko_prices = await self._gecko_source.fetch_prices(chain, network, tokens)
+            for token, price in gecko_prices.items():
+                prices[token] = price
+                publish_price(f"{token}-{quote_asset}", price)
+                logger.debug(f"Fetched GeckoTerminal price for {token}: {price} {quote_asset}")
+        except Exception as e:
+            logger.warning(f"GeckoTerminal pricing failed for {full_network}: {e}")
+
         for token in tokens:
             token_upper = token.upper()
 
             # Skip same-token quotes (e.g., USDC/USDC) - price is always 1
             if token_upper == quote_asset.upper():
                 prices[token] = Decimal("1")
-                rate_oracle.set_price(f"{token}-{quote_asset}", Decimal("1"))
+                publish_price(f"{token}-{quote_asset}", Decimal("1"))
                 logger.debug(f"Skipping same-token quote for {token}, price=1")
+                continue
+
+            # Already priced by GeckoTerminal above - no Gateway quote needed.
+            if token in prices:
                 continue
 
             try:
@@ -289,9 +318,9 @@ class GatewayWalletService:
                     elif result and "price" in result:
                         price = Decimal(str(result["price"]))
                         prices[token] = price
-                        # Also update the rate oracle so future lookups can find it
+                        # Also publish to the shared pool so future lookups can find it
                         trading_pair = f"{token}-USDC"
-                        rate_oracle.set_price(trading_pair, price)
+                        publish_price(trading_pair, price)
                         logger.debug(f"Fetched immediate price for {token}: {price} USDC")
             except Exception as e:
                 logger.error(f"Error fetching gateway prices: {e}", exc_info=True)
@@ -299,7 +328,7 @@ class GatewayWalletService:
         # Copy WETH price to ETH on ethereum networks
         if eth_needs_weth_price and "WETH" in prices:
             prices["ETH"] = prices["WETH"]
-            rate_oracle.set_price("ETH-USDC", prices["WETH"])
+            publish_price("ETH-USDC", prices["WETH"])
             logger.debug(f"Copied WETH price to ETH: {prices['WETH']} USDC")
 
         return prices

--- a/services/gecko_price_source.py
+++ b/services/gecko_price_source.py
@@ -1,0 +1,204 @@
+"""
+GeckoTerminal DEX price source.
+
+Fetches USD spot prices for on-chain (Gateway) tokens directly from the GeckoTerminal public
+API, in bulk by token contract address. This lets blockchain holdings be priced from a single
+batched HTTP call (up to 30 tokens) instead of one Gateway ``quote_swap`` per token, so DEX
+prices can be refreshed at a polling cadence similar to the CEX tickers in ``ticker_sources``.
+
+Two vocabularies have to be bridged:
+
+* The Gateway speaks ``chain-network`` ids (e.g. ``solana-mainnet-beta``, ``ethereum-base``)
+  and prices tokens by **symbol**.
+* GeckoTerminal speaks its own network ids (e.g. ``solana``, ``base``) and keys tokens by
+  **contract address**.
+
+So this module maps the network, resolves each requested symbol to its address via the Gateway
+token list (cached per network), batch-fetches USD prices, and maps the results back to symbols.
+
+The dependency (``geckoterminal-py``) is imported lazily: if it is not installed the source
+degrades to a no-op (returns ``{}``) and callers simply fall back to Gateway pricing.
+"""
+import asyncio
+import logging
+import time
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# GeckoTerminal accepts at most 30 token addresses per simple-token-price call.
+_MAX_ADDRESSES_PER_CALL = 30
+# How long a chain/network token list (symbol -> address) is cached before refetching.
+_TOKEN_LIST_TTL = 3600.0
+# Per fetch cycle timeout so a slow GeckoTerminal never stalls a balance refresh.
+_FETCH_TIMEOUT = 15.0
+
+# Gateway network segment -> GeckoTerminal network id. Keyed by the network part of the
+# Gateway ``chain-network`` id (unambiguous in Gateway: only Solana uses "mainnet-beta" and
+# only Ethereum uses "mainnet"). Networks absent here are simply not priced via GeckoTerminal.
+GATEWAY_TO_GECKO_NETWORK: Dict[str, str] = {
+    # Solana
+    "mainnet-beta": "solana",
+    # Ethereum L1 + EVM L2s / sidechains (Gateway network segment)
+    "mainnet": "eth",
+    "arbitrum": "arbitrum",
+    "optimism": "optimism",
+    "base": "base",
+    "polygon": "polygon_pos",
+    "bsc": "bsc",
+    "avalanche": "avax",
+    "blast": "blast",
+    "mode": "mode",
+    "scroll": "scroll",
+    "linea": "linea",
+    "zksync": "zksync",
+    "celo": "celo",
+}
+
+
+def gateway_network_to_gecko(network: str) -> Optional[str]:
+    """Map a Gateway network segment (e.g. ``mainnet-beta``, ``base``) to a GeckoTerminal id."""
+    return GATEWAY_TO_GECKO_NETWORK.get(network)
+
+
+def _to_decimal(value) -> Optional[Decimal]:
+    """Parse a value to a positive Decimal, returning None on empty/invalid/non-positive input."""
+    if value is None or value == "":
+        return None
+    try:
+        dec = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return dec if dec > 0 else None
+
+
+class GeckoPriceSource:
+    """Batched USD price lookups for Gateway tokens via the GeckoTerminal API.
+
+    A single async client is reused across calls. Token lists are cached per ``(chain, network)``
+    with a TTL so the address for each symbol is not refetched on every cycle.
+    """
+
+    def __init__(self, gateway_client):
+        """
+        Args:
+            gateway_client: The ``GatewayClient`` used to fetch token lists (symbol -> address).
+        """
+        self._gateway_client = gateway_client
+        self._client = None
+        self._client_unavailable = False
+        # (chain, network) -> (fetched_at, {UPPER_SYMBOL: address})
+        self._token_list_cache: Dict[Tuple[str, str], Tuple[float, Dict[str, str]]] = {}
+
+    def _get_client(self):
+        """Lazily construct the GeckoTerminal async client; return None if the dep is missing."""
+        if self._client is not None:
+            return self._client
+        if self._client_unavailable:
+            return None
+        try:
+            from geckoterminal_py import GeckoTerminalAsyncClient
+        except ImportError:
+            logger.warning(
+                "geckoterminal-py is not installed; GeckoTerminal DEX pricing disabled "
+                "(falling back to Gateway prices). Add 'geckoterminal-py' to the environment."
+            )
+            self._client_unavailable = True
+            return None
+        self._client = GeckoTerminalAsyncClient()
+        return self._client
+
+    async def close(self):
+        """Close the underlying HTTP client if it was created."""
+        if self._client is not None:
+            try:
+                await self._client.close()
+            finally:
+                self._client = None
+
+    async def _symbol_to_address(self, chain: str, network: str) -> Dict[str, str]:
+        """Return a cached ``{UPPER_SYMBOL: address}`` map for a chain/network from Gateway."""
+        key = (chain, network)
+        cached = self._token_list_cache.get(key)
+        if cached is not None and (time.time() - cached[0]) < _TOKEN_LIST_TTL:
+            return cached[1]
+
+        response = await self._gateway_client.get_tokens(chain, network)
+        tokens = response.get("tokens", []) if isinstance(response, dict) else []
+        mapping: Dict[str, str] = {}
+        for token in tokens:
+            symbol = token.get("symbol")
+            address = token.get("address")
+            if symbol and address:
+                mapping[symbol.upper()] = address
+        self._token_list_cache[key] = (time.time(), mapping)
+        return mapping
+
+    async def fetch_prices(self, chain: str, network: str, symbols: List[str]) -> Dict[str, Decimal]:
+        """
+        Fetch USD prices for the given token ``symbols`` on a Gateway chain/network.
+
+        Returns ``{symbol: price}`` (original-cased symbols, USD price as Decimal) only for
+        symbols GeckoTerminal could price. Symbols with no known address, no listed pool, or a
+        non-positive price are omitted so the caller can fall back to Gateway for those. Never
+        raises: any failure yields an empty dict.
+        """
+        gecko_network = gateway_network_to_gecko(network)
+        if not gecko_network or not symbols:
+            return {}
+        client = self._get_client()
+        if client is None:
+            return {}
+        try:
+            return await asyncio.wait_for(
+                self._fetch_prices(client, chain, network, gecko_network, symbols),
+                timeout=_FETCH_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"GeckoTerminal price fetch timed out for {chain}-{network}")
+            return {}
+        except Exception as e:  # noqa: BLE001 - pricing must never break the balance refresh
+            logger.warning(f"GeckoTerminal price fetch failed for {chain}-{network}: {e}")
+            return {}
+
+    async def _fetch_prices(self, client, chain: str, network: str, gecko_network: str,
+                            symbols: List[str]) -> Dict[str, Decimal]:
+        symbol_to_address = await self._symbol_to_address(chain, network)
+
+        # Resolve requested symbols to addresses; remember address (both exact and lowercased)
+        # -> original symbol so we can map the response back regardless of address casing.
+        addresses: List[str] = []
+        addr_to_symbol: Dict[str, str] = {}
+        for symbol in symbols:
+            address = symbol_to_address.get(symbol.upper())
+            if not address:
+                continue
+            addresses.append(address)
+            addr_to_symbol[address] = symbol
+            addr_to_symbol[address.lower()] = symbol
+        if not addresses:
+            return {}
+
+        # De-duplicate while preserving order, then chunk to the per-call address limit.
+        unique_addresses = list(dict.fromkeys(addresses))
+        chunks = [unique_addresses[i:i + _MAX_ADDRESSES_PER_CALL]
+                  for i in range(0, len(unique_addresses), _MAX_ADDRESSES_PER_CALL)]
+
+        results = await asyncio.gather(
+            *[client.get_simple_token_price(gecko_network, chunk) for chunk in chunks],
+            return_exceptions=True,
+        )
+
+        prices: Dict[str, Decimal] = {}
+        for result in results:
+            if isinstance(result, Exception):
+                logger.debug(f"GeckoTerminal chunk failed for {gecko_network}: {result}")
+                continue
+            # result is a DataFrame with columns token_address / price_usd.
+            for address, price_usd in zip(result["token_address"], result["price_usd"]):
+                symbol = addr_to_symbol.get(address) or addr_to_symbol.get(str(address).lower())
+                price = _to_decimal(price_usd)
+                if symbol and price is not None:
+                    prices[symbol] = price
+        return prices


### PR DESCRIPTION
Add a GeckoTerminal price source that batch-fetches USD prices for on-chain tokens by contract address (up to 30 per call) instead of one Gateway quote_swap per token, so DEX holdings can be priced at a polling cadence like CEX tickers. Maps the Gateway chain-network id to GeckoTerminal's network id, resolves held symbols to addresses via the Gateway token list (cached per network), and maps results back to symbols (handling both Solana and EVM address casing).

_fetch_gateway_prices_immediate now tries GeckoTerminal first and publishes covered prices into the shared pool, falling back to Gateway get_price only for tokens GeckoTerminal cannot price. The dependency is imported lazily so the app still runs (Gateway-only) if geckoterminal-py is not installed, and the HTTP client is closed on shutdown.