### PR TITLE
fix(rates): repoint rate_finder to renamed hummingbot token normalizer

### DIFF
--- a/utils/rate_finder.py
+++ b/utils/rate_finder.py
@@ -8,14 +8,14 @@ in order: a direct lookup, the reverse pair (reciprocal), or a bridged cross-rat
 any intermediate pair that shares the base or quote asset.
 
 The helper functions (``combine_to_hb_trading_pair``, ``split_hb_trading_pair`` and
-``unwrap_token_symbol``) are reused from hummingbot to keep trading-pair formatting and
-token unwrapping identical to the rest of the stack.
+``normalize_token_symbol``) are reused from hummingbot to keep trading-pair formatting and
+token normalization identical to the rest of the stack.
 """
 from decimal import Decimal
 from typing import Dict, Optional
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair, split_hb_trading_pair
-from hummingbot.core.gateway.utils import unwrap_token_symbol
+from hummingbot.core.rate_oracle.utils import normalize_token_symbol
 
 
 def find_rate(prices: Dict[str, Decimal], pair: str) -> Optional[Decimal]:
@@ -39,10 +39,15 @@ def find_rate(prices: Dict[str, Decimal], pair: str) -> Optional[Decimal]:
     if pair in prices:
         return prices[pair]
     base, quote = split_hb_trading_pair(trading_pair=pair)
-    base = unwrap_token_symbol(base)
-    quote = unwrap_token_symbol(quote)
+    base = normalize_token_symbol(base)
+    quote = normalize_token_symbol(quote)
     if base == quote:
         return Decimal("1")
+    # Re-check the direct pair after normalizing (e.g. HBOT-USD -> HBOT-USDT) before
+    # attempting reverse-pair or path-bridging lookups.
+    normalized_pair = combine_to_hb_trading_pair(base=base, quote=quote)
+    if normalized_pair in prices:
+        return prices[normalized_pair]
     reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
     if reverse_pair in prices and prices[reverse_pair] > Decimal("0"):
         return Decimal("1") / prices[reverse_pair]


### PR DESCRIPTION
Fixes #191

## Problem

HAPI fails at startup with `ModuleNotFoundError: No module named 'hummingbot.core.gateway.utils'` when built against hummingbot `development` newer than June 28. Hummingbot commit `a71a92a5` deleted `hummingbot/core/gateway/utils.py` and renamed the helper `unwrap_token_symbol` → `normalize_token_symbol`, relocating it to `hummingbot.core.rate_oracle.utils`. `utils/rate_finder.py` (introduced in `f067c37`) still imported from the deleted path, killing the whole app import chain (`main.py` → routers → deps → services → `rate_finder`).

## Changes

1. **Import fix**: `rate_finder.py` now imports `normalize_token_symbol` from `hummingbot.core.rate_oracle.utils` (its new name and location).
2. **Latent rate-resolution bug found during validation**: the `find_rate` port never re-checked the direct pair after USD→USDT normalization, so e.g. `HBOT-USD` returned `None` even with `HBOT-USDT` present in the ticker pool. Added the normalized-pair re-check to match upstream hummingbot's `find_rate`.

## Compatibility note for QA

This PR **requires** a hummingbot wheel built from `development` at/after `a71a92a5` (the module rename). It will *not* import against older wheels (e.g. `20260515`), which only have the old `unwrap_token_symbol` path — pair this with a current dev wheel when testing.

⚠️ **Wheel-build gotcha that masked this bug**: setuptools' incremental `build/lib` never propagates source-file deletions, so wheels rebuilt from an existing hummingbot checkout silently re-include the deleted `core/gateway/utils.py` (and three stale `hummingbot/cli/` files). If a rebuilt wheel still "works" with the old import, check `unzip -l dist/hummingbot-*.whl | grep gateway/utils` and purge stale files from `build/lib.*` (or delete the build dir) before building.

## Testing

- Reproduced the exact `ModuleNotFoundError` from the issue by importing `rate_finder` against post-`a71a92a5` hummingbot source.
- After the fix, with a clean-built current dev wheel installed:
  - `main.py` (the uvicorn entrypoint) imports cleanly end-to-end.
  - 9-case `find_rate` matrix passes: direct, direct-after-normalization (`HBOT-USD`), reverse, reverse-after-normalization, both cross-rate bridging paths, identity after normalization (`USD-USDT` → 1), and no-path → `None`.
- Swept every `from hummingbot...` import across routers/services/utils/models against the new layout — `hummingbot.core.gateway.utils` was the only break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)