### PR TITLE
(fix) position mode: adopt exchange truth at init, fail loudly on empty-pair switch

### DIFF
--- a/models/accounts.py
+++ b/models/accounts.py
@@ -1,5 +1,6 @@
+from typing import Any, Dict, Optional
+
 from pydantic import BaseModel, Field
-from typing import Dict, Any
 
 
 class LeverageRequest(BaseModel):
@@ -11,6 +12,11 @@ class LeverageRequest(BaseModel):
 class PositionModeRequest(BaseModel):
     """Request model for setting position mode on perpetual connectors"""
     position_mode: str = Field(description="Position mode (HEDGE or ONEWAY)")
+    trading_pair: Optional[str] = Field(
+        default=None,
+        description="Pair to register on the connector before switching. Position-mode "
+                    "implementations apply the switch through the connector's trading "
+                    "pairs, so at least one registered pair is required.")
 
 
 class CredentialRequest(BaseModel):

--- a/routers/trading.py
+++ b/routers/trading.py
@@ -424,7 +424,8 @@ async def set_position_mode(
     try:
         # Convert string to PositionMode enum
         mode = PositionMode[request.position_mode.upper()]
-        result = await accounts_service.set_position_mode(account_name, connector_name, mode)
+        result = await accounts_service.set_position_mode(
+            account_name, connector_name, mode, trading_pair=request.trading_pair)
         return result
     except KeyError:
         raise HTTPException(

--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -1063,12 +1063,14 @@ class AccountsService:
         return await self.perpetual_trading_service.set_leverage(account_name, connector_name, trading_pair, leverage)
 
     async def set_position_mode(self, account_name: str, connector_name: str,
-                               position_mode: PositionMode) -> Dict[str, str]:
+                               position_mode: PositionMode,
+                               trading_pair: Optional[str] = None) -> Dict[str, str]:
         """
         Set position mode for a perpetual connector.
         Delegates to PerpetualTradingService.
         """
-        return await self.perpetual_trading_service.set_position_mode(account_name, connector_name, position_mode)
+        return await self.perpetual_trading_service.set_position_mode(
+            account_name, connector_name, position_mode, trading_pair=trading_pair)
 
     async def get_position_mode(self, account_name: str, connector_name: str) -> Dict[str, str]:
         """

--- a/services/perpetual_trading_service.py
+++ b/services/perpetual_trading_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from fastapi import HTTPException
 from hummingbot.core.data_type.common import PositionMode
@@ -83,7 +83,8 @@ class PerpetualTradingService:
             raise HTTPException(status_code=500, detail=f"Failed to set leverage: {str(e)}")
 
     async def set_position_mode(self, account_name: str, connector_name: str,
-                                position_mode: PositionMode) -> Dict[str, str]:
+                                position_mode: PositionMode,
+                                trading_pair: Optional[str] = None) -> Dict[str, str]:
         """
         Set position mode for a perpetual connector.
 
@@ -91,6 +92,9 @@ class PerpetualTradingService:
             account_name: Name of the account
             connector_name: Name of the connector (must be perpetual)
             position_mode: PositionMode.HEDGE or PositionMode.ONEWAY
+            trading_pair: Pair to register before switching. Position-mode
+                implementations apply the switch through the connector's trading
+                pairs, so at least one registered pair is required.
 
         Returns:
             Dictionary with success status and message
@@ -107,6 +111,22 @@ class PerpetualTradingService:
             raise HTTPException(
                 status_code=400,
                 detail=f"Position mode '{position_mode.value}' not supported. Supported modes: {supported_values}"
+            )
+
+        # Position-mode implementations apply the switch through the connector's
+        # trading pairs (the py-base default and e.g. bybit both log a warning and
+        # return when the list is empty), and API connectors are created with
+        # trading_pairs=[] — so without a registered pair the exchange is never
+        # called while this endpoint would report success. Register the provided
+        # pair, then refuse to proceed with an empty list rather than lie.
+        if trading_pair:
+            from services.unified_connector_service import UnifiedConnectorService
+            await UnifiedConnectorService.sync_pair_derived_state(connector, trading_pair)
+        if not getattr(connector, "trading_pairs", None):
+            raise HTTPException(
+                status_code=400,
+                detail=f"No trading pairs registered on {connector_name}; pass trading_pair "
+                       f"so the position mode switch can be applied on the exchange"
             )
 
         try:

--- a/services/perpetual_trading_service.py
+++ b/services/perpetual_trading_service.py
@@ -104,7 +104,28 @@ class PerpetualTradingService:
         """
         connector = await self._get_perpetual_connector(account_name, connector_name)
 
-        # Check if the requested position mode is supported
+        # Register the provided pair FIRST. Position-mode implementations apply
+        # the switch through the connector's trading pairs (with an empty list the
+        # base implementation warns and returns; bybit/bitget overrides vacuously
+        # "succeed" without any exchange call), and supported_position_modes() on
+        # e.g. bybit depends on the registered pair list — validating against it
+        # before registration would vacuously pass modes the actual pair cannot
+        # support. Unknown pairs are rejected with 400 and never registered.
+        if trading_pair:
+            from services.unified_connector_service import UnifiedConnectorService
+            try:
+                await UnifiedConnectorService.sync_pair_derived_state(
+                    connector, trading_pair, refresh_rules=False)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+        if not getattr(connector, "trading_pairs", None):
+            raise HTTPException(
+                status_code=400,
+                detail=f"No trading pairs registered on {connector_name}; pass trading_pair "
+                       f"so the position mode switch can be applied on the exchange"
+            )
+
+        # Validate AFTER registration, against the real pair set
         supported_modes = connector.supported_position_modes()
         if position_mode not in supported_modes:
             supported_values = [mode.value for mode in supported_modes]
@@ -113,33 +134,35 @@ class PerpetualTradingService:
                 detail=f"Position mode '{position_mode.value}' not supported. Supported modes: {supported_values}"
             )
 
-        # Position-mode implementations apply the switch through the connector's
-        # trading pairs (the py-base default and e.g. bybit both log a warning and
-        # return when the list is empty), and API connectors are created with
-        # trading_pairs=[] — so without a registered pair the exchange is never
-        # called while this endpoint would report success. Register the provided
-        # pair, then refuse to proceed with an empty list rather than lie.
-        if trading_pair:
-            from services.unified_connector_service import UnifiedConnectorService
-            await UnifiedConnectorService.sync_pair_derived_state(connector, trading_pair)
-        if not getattr(connector, "trading_pairs", None):
-            raise HTTPException(
-                status_code=400,
-                detail=f"No trading pairs registered on {connector_name}; pass trading_pair "
-                       f"so the position mode switch can be applied on the exchange"
-            )
-
         try:
-            # Try to call the method - it might be sync or async
-            result = connector.set_position_mode(position_mode)
-            # If it's a coroutine, await it
-            if asyncio.iscoroutine(result):
-                await result
+            # Await the actual exchange call. connector.set_position_mode() is
+            # fire-and-forget (it spawns _execute_set_position_mode in the
+            # background and returns immediately), which would report success
+            # before the exchange ever responds — and cannot report a rejection
+            # (e.g. Binance -4068 with open positions). _execute_set_position_mode
+            # updates the local trait only on confirmed success, so the local mode
+            # is the truth test.
+            execute = getattr(connector, "_execute_set_position_mode", None)
+            if execute is not None:
+                await execute(position_mode)
+            else:
+                result = connector.set_position_mode(position_mode)
+                if asyncio.iscoroutine(result):
+                    await result
+
+            if getattr(connector, "position_mode", position_mode) != position_mode:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Exchange did not accept position mode {position_mode.value} on "
+                           f"{connector_name} — check for open positions/orders and connector logs"
+                )
 
             message = f"Position mode set to {position_mode.value} on {connector_name}"
             logger.info(f"Set position mode to {position_mode.value} on {connector_name} (Account: {account_name})")
             return {"status": "success", "message": message}
 
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Failed to set position mode to {position_mode.value}: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to set position mode: {str(e)}")

--- a/services/unified_connector_service.py
+++ b/services/unified_connector_service.py
@@ -24,7 +24,7 @@ from hummingbot.connector.connector_metrics_collector import TradeVolumeMetricCo
 from hummingbot.connector.exchange_py_base import ExchangePyBase
 from hummingbot.connector.gateway.gateway import Gateway
 from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
-from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
+from hummingbot.core.data_type.common import OrderType, PositionAction, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
@@ -413,6 +413,56 @@ class UnifiedConnectorService:
         return False
 
     @staticmethod
+    async def _adopt_exchange_position_mode(connector: ConnectorBase) -> None:
+        """Adopt the exchange account's actual position mode as the local truth.
+
+        The previous init behavior called ``connector.set_position_mode(HEDGE)``
+        with ``trading_pairs=[]``, and what that did depended on the connector:
+        base-class implementations warned and returned (local trait stayed at its
+        ONEWAY default), while bybit's and bitget's per-pair overrides iterated
+        the empty list, vacuously "succeeded", and flipped the LOCAL trait to
+        HEDGE — in every case without a single exchange call. Local state was
+        guesswork either way; the exchange (account default or last manual
+        setting) is the source of truth.
+
+        So instead of mutating the exchange, read its current mode and mirror it
+        locally so ``connector.position_mode``, executors, and the position-mode
+        endpoints report reality. Exchanges that cannot be queried
+        (``_fetch_account_position_mode`` returns None — e.g. bybit has no
+        override) keep the local default and operators set the mode explicitly
+        through the endpoint. Some fetch implementations need a registered pair
+        (bitget returns None with an empty pair list), so adoption is retried
+        once on the first pair registration — see sync_pair_derived_state. #210.
+        """
+        fetch = getattr(connector, "_fetch_account_position_mode", None)
+        perpetual_trading = getattr(connector, "_perpetual_trading", None)
+        if fetch is None or perpetual_trading is None:
+            return
+        try:
+            exchange_mode = await fetch()
+        except Exception as e:
+            logger.warning(
+                f"Could not fetch position mode from exchange for "
+                f"{type(connector).__name__}: {e}"
+            )
+            return
+        if exchange_mode is None or exchange_mode == connector.position_mode:
+            return
+        supported = getattr(connector, "supported_position_modes", None)
+        if supported is not None and exchange_mode not in supported():
+            logger.warning(
+                f"Exchange reports position mode {exchange_mode} but "
+                f"{type(connector).__name__} does not support it locally — keeping "
+                f"{connector.position_mode}"
+            )
+            return
+        perpetual_trading.set_position_mode(exchange_mode)
+        logger.info(
+            f"Adopted exchange position mode {exchange_mode} for "
+            f"{type(connector).__name__} (local default was stale)"
+        )
+
+    @staticmethod
     async def sync_pair_derived_state(
         connector: ConnectorBase,
         trading_pair: str,
@@ -472,6 +522,15 @@ class UnifiedConnectorService:
             connector._trading_pairs = [trading_pair]
         elif trading_pair not in pairs:
             pairs.append(trading_pair)
+
+        # 1b. One-shot position-mode adoption retry (#210): some fetch
+        # implementations need a registered pair (bitget returns None with an
+        # empty pair list), so adoption at connector init cannot work for them.
+        # Retry exactly once now that a pair exists.
+        perpetual_trading = getattr(connector, "_perpetual_trading", None)
+        if perpetual_trading is not None and not getattr(connector, "_position_mode_adoption_done", False):
+            await UnifiedConnectorService._adopt_exchange_position_mode(connector)
+            connector._position_mode_adoption_done = True
 
         # 2. Throttler rate limits (#207). add_rate_limits() skips known limit_ids.
         # Synced on data connectors too — their REST fetches go through the same
@@ -731,8 +790,7 @@ class UnifiedConnectorService:
 
         # Perpetual-specific setup
         if self._is_perpetual_connector(connector):
-            if PositionMode.HEDGE in connector.supported_position_modes():
-                connector.set_position_mode(PositionMode.HEDGE)
+            await self._adopt_exchange_position_mode(connector)
             await connector._update_positions()
 
         # Load existing orders from database

--- a/test/test_sync_pair_derived_state.py
+++ b/test/test_sync_pair_derived_state.py
@@ -229,3 +229,99 @@ def test_unknown_pair_cannot_poison_rules_refresh():
     # Valid pairs still get rules — refresh is not poisoned
     _run(UnifiedConnectorService.sync_pair_derived_state(connector, "SOLO-XRP"))
     assert "SOLO-XRP" in connector.trading_rules
+
+
+def test_set_position_mode_refuses_empty_pairs_and_registers_provided_pair():
+    """Position-mode implementations iterate connector.trading_pairs and silently
+    no-op when the list is empty — the service must refuse loudly instead of
+    reporting success, and must register a provided pair before switching."""
+    from fastapi import HTTPException
+    from hummingbot.core.data_type.common import PositionMode
+
+    from services.perpetual_trading_service import PerpetualTradingService
+
+    class FakePerpConnector(FakePairLimitsConnector):
+        def __init__(self):
+            super().__init__(trading_pairs=[])
+            self.mode_set = None
+
+        @property
+        def trading_pairs(self):
+            return self._trading_pairs or []
+
+        def supported_position_modes(self):
+            return [PositionMode.HEDGE, PositionMode.ONEWAY]
+
+        def set_position_mode(self, mode):
+            self.mode_set = mode
+
+    connector = FakePerpConnector()
+
+    async def provider(account_name, connector_name):
+        return connector
+
+    service = PerpetualTradingService(provider)
+
+    # No pair provided and none registered -> loud 400, exchange never touched
+    try:
+        _run(service.set_position_mode("master", "bybit_perpetual", PositionMode.HEDGE))
+        raise AssertionError("expected HTTPException for empty trading_pairs")
+    except HTTPException as e:
+        assert e.status_code == 400
+    assert connector.mode_set is None
+
+    # Pair provided -> registered (with rules/throttler synced), then switched
+    result = _run(service.set_position_mode(
+        "master", "bybit_perpetual", PositionMode.HEDGE, trading_pair="BTC-USDT"))
+    assert connector._trading_pairs == ["BTC-USDT"]
+    assert connector.mode_set == PositionMode.HEDGE
+    assert result["status"] == "success"
+
+
+def test_adopt_exchange_position_mode():
+    """At init the exchange is the source of truth for position mode: its current
+    mode is mirrored locally (the old HEDGE-forcing call never reached any
+    exchange). Unqueryable exchanges and fetch failures keep the local default."""
+    from hummingbot.core.data_type.common import PositionMode
+
+    class FakePerpetualTrading:
+        def __init__(self):
+            self.mode = PositionMode.ONEWAY
+
+        def set_position_mode(self, mode):
+            self.mode = mode
+
+    class FakePerp:
+        def __init__(self, exchange_mode):
+            self._exchange_mode = exchange_mode
+            self._perpetual_trading = FakePerpetualTrading()
+
+        @property
+        def position_mode(self):
+            return self._perpetual_trading.mode
+
+        async def _fetch_account_position_mode(self):
+            if isinstance(self._exchange_mode, Exception):
+                raise self._exchange_mode
+            return self._exchange_mode
+
+    # Exchange in HEDGE -> local trait adopts it
+    connector = FakePerp(PositionMode.HEDGE)
+    _run(UnifiedConnectorService._adopt_exchange_position_mode(connector))
+    assert connector.position_mode == PositionMode.HEDGE
+
+    # Exchange unqueryable (base default returns None) -> local default kept
+    connector = FakePerp(None)
+    _run(UnifiedConnectorService._adopt_exchange_position_mode(connector))
+    assert connector.position_mode == PositionMode.ONEWAY
+
+    # Fetch failure -> swallowed, local default kept
+    connector = FakePerp(ConnectionError("exchange down"))
+    _run(UnifiedConnectorService._adopt_exchange_position_mode(connector))
+    assert connector.position_mode == PositionMode.ONEWAY
+
+    # Connector without the fetch hook (non py-base) -> no-op, no raise
+    class Bare:
+        pass
+
+    _run(UnifiedConnectorService._adopt_exchange_position_mode(Bare()))

--- a/test/test_sync_pair_derived_state.py
+++ b/test/test_sync_pair_derived_state.py
@@ -249,6 +249,10 @@ def test_set_position_mode_refuses_empty_pairs_and_registers_provided_pair():
         def trading_pairs(self):
             return self._trading_pairs or []
 
+        @property
+        def position_mode(self):
+            return self.mode_set
+
         def supported_position_modes(self):
             return [PositionMode.HEDGE, PositionMode.ONEWAY]
 
@@ -270,12 +274,111 @@ def test_set_position_mode_refuses_empty_pairs_and_registers_provided_pair():
         assert e.status_code == 400
     assert connector.mode_set is None
 
-    # Pair provided -> registered (with rules/throttler synced), then switched
+    # Pair provided -> registered (with throttler synced), then switched
     result = _run(service.set_position_mode(
         "master", "bybit_perpetual", PositionMode.HEDGE, trading_pair="BTC-USDT"))
     assert connector._trading_pairs == ["BTC-USDT"]
     assert connector.mode_set == PositionMode.HEDGE
     assert result["status"] == "success"
+
+
+def test_set_position_mode_validates_against_post_registration_pair_set():
+    """supported_position_modes() on bybit depends on the registered pair list
+    and returns BOTH modes vacuously when it is empty. Validating before
+    registration would fake-accept HEDGE for an inverse pair; the mode check
+    must run against the post-registration pair set."""
+    from fastapi import HTTPException
+    from hummingbot.core.data_type.common import PositionMode
+
+    from services.perpetual_trading_service import PerpetualTradingService
+
+    class BybitLikePerp(FakePairLimitsConnector):
+        INVERSE = {"BTC-USD"}
+
+        def __init__(self):
+            super().__init__(trading_pairs=[])
+            self.mode_set = None
+
+        @property
+        def trading_pairs(self):
+            return self._trading_pairs or []
+
+        @property
+        def position_mode(self):
+            return self.mode_set
+
+        def supported_position_modes(self):
+            # Faithful to bybit: vacuous both-modes on empty; inverse pairs
+            # restrict to ONEWAY.
+            if not self.trading_pairs:
+                return [PositionMode.ONEWAY, PositionMode.HEDGE]
+            if any(p in self.INVERSE for p in self.trading_pairs):
+                return [PositionMode.ONEWAY]
+            return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+        def set_position_mode(self, mode):
+            self.mode_set = mode
+
+    connector = BybitLikePerp()
+
+    async def provider(account_name, connector_name):
+        return connector
+
+    service = PerpetualTradingService(provider)
+
+    # HEDGE + inverse pair: pre-fix this vacuously passed validation and then
+    # silently did nothing; now the mode check runs after registration -> 400.
+    try:
+        _run(service.set_position_mode(
+            "master", "bybit_perpetual", PositionMode.HEDGE, trading_pair="BTC-USD"))
+        raise AssertionError("expected HTTPException for unsupported mode")
+    except HTTPException as e:
+        assert e.status_code == 400
+        assert "not supported" in e.detail
+    assert connector.mode_set is None  # exchange never touched
+
+
+def test_set_position_mode_surfaces_exchange_rejection():
+    """The endpoint must await the real exchange call and fail loudly when the
+    exchange rejects the switch (e.g. open positions) — previously the call was
+    fire-and-forget and always reported success."""
+    from fastapi import HTTPException
+    from hummingbot.core.data_type.common import PositionMode
+
+    from services.perpetual_trading_service import PerpetualTradingService
+
+    class RejectingPerp(FakePairLimitsConnector):
+        def __init__(self):
+            super().__init__(trading_pairs=["BTC-USDT"])
+            self.execute_calls = 0
+
+        @property
+        def trading_pairs(self):
+            return self._trading_pairs or []
+
+        @property
+        def position_mode(self):
+            return PositionMode.ONEWAY  # local trait never updated: rejection
+
+        def supported_position_modes(self):
+            return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+        async def _execute_set_position_mode(self, mode):
+            self.execute_calls += 1  # exchange rejected; trait stays ONEWAY
+
+    connector = RejectingPerp()
+
+    async def provider(account_name, connector_name):
+        return connector
+
+    service = PerpetualTradingService(provider)
+
+    try:
+        _run(service.set_position_mode("master", "bybit_perpetual", PositionMode.HEDGE))
+        raise AssertionError("expected HTTPException for rejected switch")
+    except HTTPException as e:
+        assert e.status_code == 502
+    assert connector.execute_calls == 1  # the exchange call was actually awaited
 
 
 def test_adopt_exchange_position_mode():


### PR DESCRIPTION
Fixes #210. **Stacked on the #208 fix** (base branch `fix/208-per-pair-trading-rules`) — retarget after it merges.

Makes position mode honest. Both problems stem from connectors being created with `trading_pairs=[]` while position-mode implementations apply the switch **through the pair list**.

## 1. Init: adopt the exchange's mode instead of forcing HEDGE

The old `connector.set_position_mode(HEDGE)` at init ran with an empty pair list, and what it did depended on the connector: **base-class implementations warned and returned** (local trait stayed ONEWAY), while **bybit's and bitget's per-pair overrides iterated the empty list, vacuously "succeeded", and flipped the LOCAL trait to HEDGE** — in every case without a single exchange call. Local state was guesswork either way.

`_adopt_exchange_position_mode` reads the exchange's actual mode via `_fetch_account_position_mode()` and mirrors it locally (guarded by `supported_position_modes`), so `position_mode`, executors, and the get endpoint report reality. Unqueryable exchanges (bybit has no fetch override) keep the local default and operators set mode explicitly. Because bitget's fetch needs a registered pair, **adoption is retried once on the first pair registration** — otherwise it would be dead code at init for bitget.

**Behavior note (deliberate):** on bybit/bitget accounts whose exchange is genuinely in HEDGE, the old vacuous local-HEDGE happened to match; adoption keeps them matching where queryable (bitget, after first pair) and requires an explicit switch where not (bybit). On ONEWAY accounts this PR fixes the standing local/exchange mismatch that caused reduce-only rejections.

## 2. Switch endpoint: register first, validate against reality, await the exchange

- `PositionModeRequest` gains optional `trading_pair` (backwards compatible). The pair is **registered before validation** — bybit's `supported_position_modes()` depends on the registered pair list and returns both modes vacuously when empty, so validating first fake-accepted HEDGE for inverse pairs. Unknown pairs → 400, never registered.
- Empty pair list → **400 with instructions** instead of the previous false success.
- The switch **awaits `_execute_set_position_mode`** (the old `set_position_mode` call is fire-and-forget and cannot report rejection, e.g. Binance -4068 with open positions) and verifies the local trait after — **502 when the exchange refused**.

**Coordination:** `hummingbot-api-client` needs the optional `trading_pair` field; until then callers should set leverage first (which registers the pair). Condor's MCP tool has been reordered accordingly.

## Tests

Refuse-empty / register-and-switch; post-registration validation (bybit-faithful vacuous-modes fake); exchange-rejection surfaces as 502 with the call actually awaited; adoption (adopt/unqueryable/failure/no-hook). Suite: 102 passed, same 7 pre-existing failures as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
