### PR TITLE
feat(gateway): default Gateway image to hummingbot/gateway:development

### DIFF
--- a/models/gateway.py
+++ b/models/gateway.py
@@ -19,7 +19,7 @@ class GatewayConfig(BaseModel):
       clients (which use ``CONFIG_PASSWORD``). The passphrase is therefore always
       ``CONFIG_PASSWORD``; a separate value would only break the API<->Gateway mTLS chain.
     """
-    image: str = Field(default="hummingbot/gateway:latest", description="Docker image for Gateway")
+    image: str = Field(default="hummingbot/gateway:development", description="Docker image for Gateway")
     port: int = Field(default=15888, description="Port for Gateway API")
 
 


### PR DESCRIPTION
## Summary
- Change the `/gateway/start` default image from `hummingbot/gateway:latest` to `hummingbot/gateway:development`.
- Meteora DAMM v2 support (the `/gateway/amm/*` routes backing `GatewayAMMRouter` in hummingbot-api-client 1.5.7) currently only ships in the `development` Gateway image — the published `latest` image has no AMM routes for Meteora, so starting Gateway with defaults produced a deployment that cannot serve DAMM v2 agents.

## Test plan
- `POST /gateway/start` with an empty body → container comes up on `hummingbot/gateway:development`, `/gateway/connectors` reports meteora `['clmm', 'amm']`.
- End-to-end: `client.gateway_amm.get_pool_info()` against a live Meteora DAMM v2 pool returns price/reserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)