### PR TITLE
feat: Add options contract holdings parsing & mark pricing support for Derive exchange

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,13 @@ def patched_save_to_yml(yml_path, cm):
 
 config_helpers.save_to_yml = patched_save_to_yml
 
+# Apply Derive options connector patch at application launch
+try:
+    from utils.patch_derive_connector import apply_derive_options_patch
+    apply_derive_options_patch()
+except Exception as e:
+    logging.warning(f"Could not apply Derive options patch on launch: {e}")
+
 from fastapi import Depends, FastAPI, HTTPException, Request, status  # noqa: E402
 from fastapi.exceptions import RequestValidationError  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402

--- a/services/accounts_service.py
+++ b/services/accounts_service.py
@@ -57,6 +57,7 @@ class AccountsService:
         "backpack_perpetual": "USDC",
         "cube": "USDC",
         "derive": "USDC",
+        "derive_options": "USDC",
         "derive_perpetual": "USDC",
         "dexalot": "USDC",
         "vertex": "USDC",
@@ -508,23 +509,36 @@ class AccountsService:
 
         for balance in balances:
             token = balance["token"]
-            if "USD" in token:
+            if "USD" in token and "-" not in token:
                 price = Decimal("1")
             else:
-                # Price using THIS connector's own tickers and its native quote (instant,
-                # in-memory cross-rate resolution). Using the connector's own quote avoids
-                # mismatches on exchanges that don't list the global quote (e.g. hyperliquid
-                # quotes in USDC/USD, not USDT).
-                base, quote = self._market_components(token, connector_name)
-                rate = self._market_data_service.get_rate_for_connector(connector_name, base, quote)
-                if rate and rate > 0:
-                    price = rate
+                # Check if connector provides custom token price (e.g. option contract mark price)
+                custom_price = None
+                if hasattr(connector, "get_token_price"):
+                    try:
+                        raw_price = connector.get_token_price(token)
+                        if raw_price is not None:
+                            custom_price = Decimal(str(raw_price))
+                    except Exception:
+                        custom_price = None
+
+                if custom_price is not None and custom_price > Decimal("0"):
+                    price = custom_price
                 else:
-                    # Queue for fallback batch fetch from exchange
-                    market = f"{base}-{quote}"
-                    missing_pairs.append(market)
-                    missing_indices.append(len(tokens_info))
-                    price = None  # resolved below
+                    # Price using THIS connector's own tickers and its native quote (instant,
+                    # in-memory cross-rate resolution). Using the connector's own quote avoids
+                    # mismatches on exchanges that don't list the global quote (e.g. hyperliquid
+                    # quotes in USDC/USD, not USDT).
+                    base, quote = self._market_components(token, connector_name)
+                    rate = self._market_data_service.get_rate_for_connector(connector_name, base, quote)
+                    if rate and rate > 0:
+                        price = rate
+                    else:
+                        # Queue for fallback batch fetch from exchange
+                        market = f"{base}-{quote}"
+                        missing_pairs.append(market)
+                        missing_indices.append(len(tokens_info))
+                        price = None  # resolved below
 
             tokens_info.append(balance_entry(
                 token,
@@ -566,9 +580,15 @@ class AccountsService:
                 logger.warning(f"Failed to get price for a pair: {result}")
                 continue
             pair, price = result
-            if price and price > 0:
-                self._last_known_prices[pair] = price
-            last_traded[pair] = price
+            price_dec = None
+            if price is not None:
+                try:
+                    price_dec = Decimal(str(price))
+                except Exception:
+                    pass
+            if price_dec is not None and price_dec > 0:
+                self._last_known_prices[pair] = price_dec
+                last_traded[pair] = price_dec
 
         # Fill in fallbacks for any pairs that failed
         missing_pairs = [pair for pair in trading_pairs if pair not in last_traded]

--- a/services/ticker_sources.py
+++ b/services/ticker_sources.py
@@ -592,10 +592,10 @@ TICKER_ADAPTERS: Dict[
 # ==================== Generic adapter (price-only, any connector) ====================
 
 # Candidate field names, ordered by preference, used to parse arbitrary exchange ticker rows.
-_SYMBOL_KEYS = ("symbol", "currency_pair", "instId", "symbolName", "trading_pair", "market", "pair", "s")
+_SYMBOL_KEYS = ("symbol", "currency_pair", "instId", "symbolName", "trading_pair", "market", "pair", "s", "instrument_name")
 _LAST_KEYS = ("last", "lastPrice", "lastPr", "close", "price", "c", "lastTradeRate")
-_BID_KEYS = ("bidPrice", "highest_bid", "bidPx", "buy", "bestBid", "bid", "b")
-_ASK_KEYS = ("askPrice", "lowest_ask", "askPx", "sell", "bestAsk", "ask", "a")
+_BID_KEYS = ("bidPrice", "highest_bid", "bidPx", "buy", "bestBid", "bid", "b", "best_bid", "best_bid_price")
+_ASK_KEYS = ("askPrice", "lowest_ask", "askPx", "sell", "bestAsk", "ask", "a", "best_ask", "best_ask_price")
 
 
 def _first(row: Dict[str, Any], keys: Tuple[str, ...]) -> Any:
@@ -610,7 +610,16 @@ def _first(row: Dict[str, Any], keys: Tuple[str, ...]) -> Any:
 def _heuristic_rows(raw: Any) -> List[Dict[str, Any]]:
     """Coerce an arbitrary 'all tickers' payload into a flat list of row dicts."""
     if isinstance(raw, list):
-        return [r for r in raw if isinstance(r, dict)]
+        rows = []
+        for r in raw:
+            if isinstance(r, dict):
+                if "symbol" in r and isinstance(r["symbol"], dict):
+                    merged = {k: v for k, v in r.items() if k != "symbol"}
+                    merged.update(r["symbol"])
+                    rows.append(merged)
+                else:
+                    rows.append(r)
+        return rows
     if isinstance(raw, dict):
         data = raw.get("data")
         if isinstance(data, list):

--- a/test/test_derive_options_integration.py
+++ b/test/test_derive_options_integration.py
@@ -1,0 +1,146 @@
+"""
+Unit and integration test for Derive options holdings parsing and valuation.
+"""
+import asyncio
+import os
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("hummingbot")
+
+from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange
+from services.accounts_service import AccountsService
+
+# Scrubbed test credentials (can be overridden via env vars for integration testing)
+TEST_DERIVE_API_KEY = os.getenv("TEST_DERIVE_API_KEY", "test_derive_api_key")
+TEST_DERIVE_API_SECRET = os.getenv("TEST_DERIVE_API_SECRET", "test_derive_api_secret")
+TEST_DERIVE_SUB_ID = int(os.getenv("TEST_DERIVE_SUB_ID", "10000"))
+
+
+def create_test_derive_connector() -> DeriveExchange:
+    """Helper to instantiate DeriveExchange with scrubbed test credentials."""
+    return DeriveExchange(
+        derive_api_key=TEST_DERIVE_API_KEY,
+        derive_api_secret=TEST_DERIVE_API_SECRET,
+        sub_id=TEST_DERIVE_SUB_ID,
+    )
+
+
+async def test_derive_exchange_positions_parsing():
+    print("Testing DeriveExchange positions parsing...")
+    connector = create_test_derive_connector()
+
+    # Mock response matching Derive private/get_subaccount payload structure
+    mock_api_response = {
+        "result": {
+            "collaterals": [
+                {"asset_name": "USDC", "amount": "1000.50"}
+            ],
+            "positions": [
+                {
+                    "instrument_name": "ETH-20260925-3000-C",
+                    "instrument_type": "option",
+                    "amount": "2.5",
+                    "mark_price": "250.75",
+                    "mark_value": "626.875",
+                    "unrealized_pnl": "50.25",
+                    "index_price": "3200.00",
+                    "delta": "0.55",
+                    "gamma": "0.002",
+                    "theta": "-4.5",
+                    "vega": "15.0",
+                },
+                {
+                    "instrument_name": "BTC-20241227-100000-P",
+                    "instrument_type": "option",
+                    "amount": "1.0",
+                    "mark_price": "1200.00",
+                    "mark_value": "1200.00",
+                    "unrealized_pnl": "-100.00",
+                    "index_price": "95000.00",
+                    "delta": "-0.25",
+                    "gamma": "0.0001",
+                    "theta": "-10.0",
+                    "vega": "25.0",
+                }
+            ]
+        }
+    }
+
+    connector._api_post = AsyncMock(return_value=mock_api_response)
+
+    await connector._update_balances()
+
+    balances = connector.get_all_balances()
+    print("Balances parsed:", balances)
+    assert balances.get("USDC") == Decimal("1000.50")
+    assert balances.get("ETH-20260925-3000-C") == Decimal("2.5")
+    assert balances.get("BTC-20241227-100000-P") == Decimal("1.0")
+
+    # Verify custom token price getter
+    eth_opt_price = connector.get_token_price("ETH-20260925-3000-C")
+    btc_opt_price = connector.get_token_price("BTC-20241227-100000-P")
+    print("ETH Option Mark Price:", eth_opt_price)
+    print("BTC Option Mark Price:", btc_opt_price)
+    assert eth_opt_price == Decimal("250.75")
+    assert btc_opt_price == Decimal("1200.00")
+
+    # Verify option metadata
+    option_positions = connector.get_option_positions()
+    assert "ETH-20260925-3000-C" in option_positions
+    assert option_positions["ETH-20260925-3000-C"]["delta"] == Decimal("0.55")
+
+    print("DeriveExchange positions parsing test passed successfully!")
+
+
+async def test_accounts_service_token_info():
+    print("Testing AccountsService token info for options...")
+    db_manager = MagicMock()
+    connector_service = MagicMock()
+    market_data_service = MagicMock()
+    market_data_service.get_rate_for_connector.return_value = None
+    trading_service = MagicMock()
+
+    accounts_service = AccountsService(
+        db_manager=db_manager,
+        connector_service=connector_service,
+        market_data_service=market_data_service,
+        trading_service=trading_service,
+    )
+
+    mock_connector = create_test_derive_connector()
+    mock_connector._account_balances = {
+        "USDC": Decimal("1000.50"),
+        "ETH-20260925-3000-C": Decimal("2.5"),
+    }
+    mock_connector._account_available_balances = {
+        "USDC": Decimal("1000.50"),
+        "ETH-20260925-3000-C": Decimal("2.5"),
+    }
+    mock_connector._position_mark_prices = {
+        "ETH-20260925-3000-C": Decimal("250.75"),
+    }
+
+    print("DEBUG mock_connector hasattr get_token_price:", hasattr(mock_connector, "get_token_price"))
+    print("DEBUG mock_connector get_token_price:", mock_connector.get_token_price("ETH-20260925-3000-C"))
+
+    tokens_info = await accounts_service._get_connector_tokens_info(
+        connector=mock_connector,
+        connector_name="derive",
+        skip_balance_refresh=True
+    )
+
+    print("Tokens info generated:", tokens_info)
+    eth_info = next(t for t in tokens_info if t["token"] == "ETH-20260925-3000-C")
+    assert eth_info["price"] == 250.75
+    assert eth_info["units"] == 2.5
+    assert eth_info["value"] == 626.875
+
+    print("AccountsService token info test passed successfully!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_derive_exchange_positions_parsing())
+    asyncio.run(test_accounts_service_token_info())

--- a/test/test_derive_options_integration.py
+++ b/test/test_derive_options_integration.py
@@ -28,6 +28,7 @@ def create_test_derive_connector() -> DeriveExchange:
     )
 
 
+@pytest.mark.asyncio
 async def test_derive_exchange_positions_parsing():
     print("Testing DeriveExchange positions parsing...")
     connector = create_test_derive_connector()
@@ -95,6 +96,7 @@ async def test_derive_exchange_positions_parsing():
     print("DeriveExchange positions parsing test passed successfully!")
 
 
+@pytest.mark.asyncio
 async def test_accounts_service_token_info():
     print("Testing AccountsService token info for options...")
     db_manager = MagicMock()

--- a/test/test_derive_options_integration.py
+++ b/test/test_derive_options_integration.py
@@ -12,6 +12,10 @@ pytest.importorskip("hummingbot")
 
 from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange
 from services.accounts_service import AccountsService
+from utils.patch_derive_connector import apply_derive_options_patch
+
+# Ensure Derive options patch is applied to DeriveExchange before tests run
+apply_derive_options_patch()
 
 # Scrubbed test credentials (can be overridden via env vars for integration testing)
 TEST_DERIVE_API_KEY = os.getenv("TEST_DERIVE_API_KEY", "test_derive_api_key")
@@ -21,6 +25,7 @@ TEST_DERIVE_SUB_ID = int(os.getenv("TEST_DERIVE_SUB_ID", "10000"))
 
 def create_test_derive_connector() -> DeriveExchange:
     """Helper to instantiate DeriveExchange with scrubbed test credentials."""
+    apply_derive_options_patch()
     return DeriveExchange(
         derive_api_key=TEST_DERIVE_API_KEY,
         derive_api_secret=TEST_DERIVE_API_SECRET,

--- a/utils/patch_derive_connector.py
+++ b/utils/patch_derive_connector.py
@@ -1,0 +1,156 @@
+"""
+Patch script for updating Derive exchange connector inside Hummingbot container / environment
+to track options contract positions alongside collateral balances.
+"""
+import os
+import sys
+
+TARGET_PATH = "/opt/conda/envs/hummingbot-api/lib/python3.12/site-packages/hummingbot/connector/exchange/derive/derive_exchange.py"
+
+OLD_INIT_SNIPPET = """        self._instrument_ticker = []
+        super().__init__(balance_asset_limit, rate_limits_share_pct)
+        self.real_time_balance_update = False"""
+
+NEW_INIT_SNIPPET = """        self._instrument_ticker = []
+        self._position_mark_prices = {}
+        self._option_positions = {}
+        super().__init__(balance_asset_limit, rate_limits_share_pct)
+        self.real_time_balance_update = False"""
+
+OLD_UPDATE_BALANCES = """    async def _update_balances(self):
+        \"\"\"
+        Calls the REST API to update total and available balances.
+        \"\"\"
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+
+        account_info = await self._api_post(
+            path_url=CONSTANTS.ACCOUNTS_PATH_URL,
+            data={"subaccount_id": self._sub_id},
+            is_auth_required=True)
+        if "error" in account_info:
+            self.logger().error(f"Error fetching account balances: {account_info['error']['message']}")
+            raise
+        else:
+            balances = account_info["result"]["collaterals"]
+            for balance_entry in balances:
+                asset_name = balance_entry["asset_name"]
+                free_balance = Decimal(balance_entry["amount"])
+                total_balance = Decimal(balance_entry["amount"])
+                self._account_available_balances[asset_name] = free_balance
+                self._account_balances[asset_name] = total_balance
+                remote_asset_names.add(asset_name)
+
+            asset_names_to_remove = local_asset_names.difference(remote_asset_names)
+            for asset_name in asset_names_to_remove:
+                del self._account_available_balances[asset_name]
+                del self._account_balances[asset_name]"""
+
+NEW_UPDATE_BALANCES = """    async def _update_balances(self):
+        \"\"\"
+        Calls the REST API to update total and available balances (collaterals and active positions).
+        \"\"\"
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+
+        account_info = await self._api_post(
+            path_url=CONSTANTS.ACCOUNTS_PATH_URL,
+            data={"subaccount_id": self._sub_id},
+            is_auth_required=True)
+        if "error" in account_info:
+            self.logger().error(f"Error fetching account balances: {account_info['error']['message']}")
+            raise
+        else:
+            balances = account_info["result"].get("collaterals", [])
+            for balance_entry in balances:
+                asset_name = balance_entry["asset_name"]
+                free_balance = Decimal(str(balance_entry["amount"]))
+                total_balance = Decimal(str(balance_entry["amount"]))
+                self._account_available_balances[asset_name] = free_balance
+                self._account_balances[asset_name] = total_balance
+                remote_asset_names.add(asset_name)
+
+            positions = account_info["result"].get("positions", [])
+            self._position_mark_prices.clear()
+            self._option_positions.clear()
+
+            for pos in positions:
+                instrument_name = pos.get("instrument_name")
+                if not instrument_name:
+                    continue
+                amount = Decimal(str(pos.get("amount", 0)))
+                if amount != 0:
+                    mark_price = Decimal(str(pos.get("mark_price", 0)))
+                    self._account_available_balances[instrument_name] = amount
+                    self._account_balances[instrument_name] = amount
+                    self._position_mark_prices[instrument_name] = mark_price
+                    self._option_positions[instrument_name] = {
+                        "instrument_name": instrument_name,
+                        "instrument_type": pos.get("instrument_type"),
+                        "amount": amount,
+                        "mark_price": mark_price,
+                        "mark_value": Decimal(str(pos.get("mark_value", 0))),
+                        "unrealized_pnl": Decimal(str(pos.get("unrealized_pnl", 0))),
+                        "index_price": Decimal(str(pos.get("index_price", 0))),
+                        "delta": Decimal(str(pos.get("delta", 0))),
+                        "gamma": Decimal(str(pos.get("gamma", 0))),
+                        "theta": Decimal(str(pos.get("theta", 0))),
+                        "vega": Decimal(str(pos.get("vega", 0))),
+                    }
+                    remote_asset_names.add(instrument_name)
+
+            asset_names_to_remove = local_asset_names.difference(remote_asset_names)
+            for asset_name in asset_names_to_remove:
+                del self._account_available_balances[asset_name]
+                del self._account_balances[asset_name]
+
+    def get_token_price(self, token: str) -> Optional[Decimal]:
+        \"\"\"
+        Returns the mark price for an option position or token if available.
+        \"\"\"
+        if hasattr(self, "_position_mark_prices") and token in self._position_mark_prices:
+            return self._position_mark_prices[token]
+        return None
+
+    def get_option_positions(self) -> Dict[str, Dict]:
+        \"\"\"
+        Returns cached option positions metadata.
+        \"\"\"
+        if hasattr(self, "_option_positions"):
+            return self._option_positions
+        return {}"""
+
+def patch_file(file_path: str):
+    if not os.path.exists(file_path):
+        print(f"Target file not found: {file_path}")
+        return False
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if "get_option_positions" in content:
+        print("Derive exchange connector is already patched.")
+        return True
+
+    if OLD_INIT_SNIPPET not in content:
+        print("OLD_INIT_SNIPPET not matched.")
+        return False
+
+    content = content.replace(OLD_INIT_SNIPPET, NEW_INIT_SNIPPET)
+
+    if OLD_UPDATE_BALANCES not in content:
+        print("OLD_UPDATE_BALANCES not matched.")
+        return False
+
+    content = content.replace(OLD_UPDATE_BALANCES, NEW_UPDATE_BALANCES)
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    print("Successfully patched Derive exchange connector!")
+    return True
+
+if __name__ == "__main__":
+    target = sys.argv[1] if len(sys.argv) > 1 else TARGET_PATH
+    success = patch_file(target)
+    sys.exit(0 if success else 1)

--- a/utils/patch_derive_connector.py
+++ b/utils/patch_derive_connector.py
@@ -1,9 +1,121 @@
 """
-Patch script for updating Derive exchange connector inside Hummingbot container / environment
-to track options contract positions alongside collateral balances.
+Patch script and runtime monkey-patch helper for updating Derive exchange connector
+in Hummingbot environment to track options contract positions alongside collateral balances.
 """
+from decimal import Decimal
 import os
 import sys
+from typing import Dict, Optional
+
+
+def apply_derive_options_patch() -> bool:
+    """
+    Applies options contract position tracking and mark price retrieval methods
+    directly to `DeriveExchange` class in Python memory.
+    Safe and idempotent to call on startup.
+    """
+    try:
+        from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange
+        from hummingbot.connector.exchange.derive import derive_constants as CONSTANTS
+    except ImportError:
+        return False
+
+    if hasattr(DeriveExchange, "get_token_price") and hasattr(DeriveExchange, "get_option_positions"):
+        return True
+
+    orig_init = DeriveExchange.__init__
+
+    def patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        self._position_mark_prices = {}
+        self._option_positions = {}
+
+    async def patched_update_balances(self):
+        """
+        Calls the REST API to update total and available balances (collaterals and active positions).
+        """
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+
+        account_info = await self._api_post(
+            path_url=CONSTANTS.ACCOUNTS_PATH_URL,
+            data={"subaccount_id": self._sub_id},
+            is_auth_required=True
+        )
+        if "error" in account_info:
+            self.logger().error(f"Error fetching account balances: {account_info['error']['message']}")
+            raise Exception(account_info["error"]["message"])
+        else:
+            balances = account_info["result"].get("collaterals", [])
+            for balance_entry in balances:
+                asset_name = balance_entry["asset_name"]
+                free_balance = Decimal(str(balance_entry["amount"]))
+                total_balance = Decimal(str(balance_entry["amount"]))
+                self._account_available_balances[asset_name] = free_balance
+                self._account_balances[asset_name] = total_balance
+                remote_asset_names.add(asset_name)
+
+            positions = account_info["result"].get("positions", [])
+            if not hasattr(self, "_position_mark_prices"):
+                self._position_mark_prices = {}
+            if not hasattr(self, "_option_positions"):
+                self._option_positions = {}
+
+            self._position_mark_prices.clear()
+            self._option_positions.clear()
+
+            for pos in positions:
+                instrument_name = pos.get("instrument_name")
+                if not instrument_name:
+                    continue
+                amount = Decimal(str(pos.get("amount", 0)))
+                if amount != 0:
+                    mark_price = Decimal(str(pos.get("mark_price", 0)))
+                    self._account_available_balances[instrument_name] = amount
+                    self._account_balances[instrument_name] = amount
+                    self._position_mark_prices[instrument_name] = mark_price
+                    self._option_positions[instrument_name] = {
+                        "instrument_name": instrument_name,
+                        "instrument_type": pos.get("instrument_type"),
+                        "amount": amount,
+                        "mark_price": mark_price,
+                        "mark_value": Decimal(str(pos.get("mark_value", 0))),
+                        "unrealized_pnl": Decimal(str(pos.get("unrealized_pnl", 0))),
+                        "index_price": Decimal(str(pos.get("index_price", 0))),
+                        "delta": Decimal(str(pos.get("delta", 0))),
+                        "gamma": Decimal(str(pos.get("gamma", 0))),
+                        "theta": Decimal(str(pos.get("theta", 0))),
+                        "vega": Decimal(str(pos.get("vega", 0))),
+                    }
+                    remote_asset_names.add(instrument_name)
+
+            asset_names_to_remove = local_asset_names.difference(remote_asset_names)
+            for asset_name in asset_names_to_remove:
+                del self._account_available_balances[asset_name]
+                del self._account_balances[asset_name]
+
+    def get_token_price(self, token: str) -> Optional[Decimal]:
+        """
+        Returns the mark price for an option position or token if available.
+        """
+        if hasattr(self, "_position_mark_prices") and token in self._position_mark_prices:
+            return self._position_mark_prices[token]
+        return None
+
+    def get_option_positions(self) -> Dict[str, Dict]:
+        """
+        Returns cached option positions metadata.
+        """
+        if hasattr(self, "_option_positions"):
+            return self._option_positions
+        return {}
+
+    DeriveExchange.__init__ = patched_init
+    DeriveExchange._update_balances = patched_update_balances
+    DeriveExchange.get_token_price = get_token_price
+    DeriveExchange.get_option_positions = get_option_positions
+    return True
+
 
 TARGET_PATH = "/opt/conda/envs/hummingbot-api/lib/python3.12/site-packages/hummingbot/connector/exchange/derive/derive_exchange.py"
 
@@ -120,6 +232,7 @@ NEW_UPDATE_BALANCES = """    async def _update_balances(self):
             return self._option_positions
         return {}"""
 
+
 def patch_file(file_path: str):
     if not os.path.exists(file_path):
         print(f"Target file not found: {file_path}")
@@ -149,6 +262,7 @@ def patch_file(file_path: str):
 
     print("Successfully patched Derive exchange connector!")
     return True
+
 
 if __name__ == "__main__":
     target = sys.argv[1] if len(sys.argv) > 1 else TARGET_PATH


### PR DESCRIPTION
## Description
This PR introduces support for parsing, valuation, and mark pricing of options contract holdings (specifically targeting options on the **Derive** exchange connector and generalizing generic ticker row handling).

### Motivation
Options instruments (e.g. `ETH-20260925-3000-C`) require custom handling compared to standard spot assets:
1. Standard spot ticker feeds don't list explicit trading pairs like `ETH-20260925-3000-C-USDC`.
2. Option symbol strings containing `"USD"` (such as option contracts quoted in USD) were previously at risk of being treated as $1.00 USD stablecoins by default.
3. Option positions and collateral balances need to be extracted together from exchange account endpoints.

---

## Key Changes

### 1. `services/accounts_service.py`
* **Added `derive_options` Quote Mapping**: Mapped `"derive_options": "USDC"` in default `QUOTE_ASSETS`.
* **Refined Stablecoin Check (`"USD" in token and "-" not in token`)**: Prevents option symbols containing "USD" (e.g., options contracts) from being hardcoded to a $1.00 valuation.
* **Added Custom Token Price Hook (`connector.get_token_price(token)`)**: Allows connectors (like options exchanges) to return mark prices directly for non-standard assets, safely casting to `Decimal`.

### 2. `services/ticker_sources.py`
* **Extended Key Mappings**: Added `"instrument_name"` to `_SYMBOL_KEYS`, and `"best_bid"`, `"best_bid_price"`, `"best_ask"`, `"best_ask_price"` to bid/ask keys.
* **Nested Dict Unpacking in `_heuristic_rows`**: Flattens nested `"symbol"` dictionaries (e.g., `{"symbol": {"instrument_name": "ETH-PERP"}, ...}`) so generic ticker adapters can process options and perps feeds without error.

### 3. `utils/patch_derive_connector.py`
* **Connector Patch Script**: Updates `DeriveExchange._update_balances()` to pull `positions` (active options and perps) alongside `collaterals` from `/api/v1/private/get_subaccount`. Exposes `get_token_price()` and `get_option_positions()` for Greeks and mark price metadata.

### 4. `test/test_derive_options_integration.py`
* **Integration & Unit Tests**: Added unit tests covering Derive positions payload parsing, mark price retrieval, Greeks metadata, and `AccountsService` token info integration (using scrubbed test credentials).

---

## Verification & Testing

- [x] Verified `AccountsService` option mark price resolution using custom connector hook.
- [x] Verified `_heuristic_rows` parsing with nested symbol dictionary structures.
- [x] Unit test suite added in `test/test_derive_options_integration.py` passing with mock responses.
- [x] All test credentials scrubbed and environment-gated with `pytest.importorskip("hummingbot")`.
