### PR TITLE
feat(connectors): expose config field prompts in the config-map endpoint

### DIFF
--- a/routers/connectors.py
+++ b/routers/connectors.py
@@ -36,19 +36,21 @@ async def get_connector_config_map(connector_name: str, accounts_service: Accoun
         Each field contains:
         - type: The expected data type (e.g., "str", "SecretStr", "int")
         - required: Whether the field is required
+        - allowed_values: List of accepted values (only for Literal fields)
+        - prompt: Human readable prompt from the Hummingbot config map (when defined)
     """
     return accounts_service.get_connector_config_map(connector_name)
 
 
 @router.get("/{connector_name}/trading-rules")
 async def get_trading_rules(
-    request: Request, 
+    request: Request,
     connector_name: str,
     trading_pairs: Optional[List[str]] = Query(default=None, description="Filter by specific trading pairs")
 ):
     """
     Get trading rules for a connector, optionally filtered by trading pairs.
-    
+
     This endpoint uses the MarketDataService to access non-trading connector instances,
     which means no authentication or account setup is required.
 
@@ -68,12 +70,12 @@ async def get_trading_rules(
 
         # Get trading rules (filtered by trading pairs if provided)
         rules = await market_data_service.get_trading_rules(connector_name, trading_pairs)
-        
+
         if "error" in rules:
             raise HTTPException(status_code=404, detail=f"Connector '{connector_name}' not found or error: {rules['error']}")
-        
+
         return rules
-        
+
     except HTTPException:
         raise
     except Exception as e:

--- a/services/unified_connector_service.py
+++ b/services/unified_connector_service.py
@@ -1361,9 +1361,40 @@ class UnifiedConnectorService:
             field_info = {"type": type_name, "required": field.is_required()}
             if allowed_values is not None:
                 field_info["allowed_values"] = allowed_values
+
+            prompt = UnifiedConnectorService._resolve_field_prompt(
+                field, connector_config.hb_config
+            )
+            if prompt is not None:
+                field_info["prompt"] = prompt
+
             fields_info[key] = field_info
 
         return fields_info
+
+    @staticmethod
+    def _resolve_field_prompt(field, config_map) -> Optional[str]:
+        """Resolve the Hummingbot prompt of a config field, if it defines one.
+
+        Prompts are stored in ``json_schema_extra`` either as a plain string or as
+        a callable taking the config map, so callables are evaluated here.
+        """
+        extra = field.json_schema_extra
+        if not isinstance(extra, dict):
+            return None
+
+        prompt = extra.get("prompt")
+        if prompt is None:
+            return None
+
+        if callable(prompt):
+            try:
+                prompt = prompt(config_map)
+            except Exception as e:
+                logger.debug(f"Could not resolve prompt for config field: {e}")
+                return None
+
+        return str(prompt) if prompt is not None else None
 
     # =========================================================================
     # Cleanup


### PR DESCRIPTION
## What

`GET /connectors/{connector_name}/config-map` now returns the human readable `prompt` that Hummingbot already defines for each credential field, alongside the existing `type` / `required` / `allowed_values`.

Before, clients had to invent their own labels for connector credential forms.

## How

Prompts live in each field's `json_schema_extra`, either as a plain string (e.g. `binance_perpetual`, `pacifica_perpetual`) or as a callable taking the config map (e.g. `binance` uses lambdas). `_resolve_field_prompt` handles both and simply omits the key if resolving one raises, so a misbehaving connector can't break the endpoint.

## Example

`GET /connectors/pacifica_perpetual/config-map`

```json
{
  "pacifica_perpetual_agent_wallet_public_key": {
    "type": "SecretStr",
    "required": true,
    "prompt": "Enter your Pacifica Perpetual Agent Wallet Public Key"
  },
  "pacifica_perpetual_api_config_key": {
    "type": "SecretStr",
    "required": false,
    "prompt": "Enter your Pacifica Perpetual API Config Key (optional)"
  }
}
```

## Testing

Ran the config map against `pacifica_perpetual`, `binance` (callable prompts), `kraken` and `hyperliquid_perpetual` (Literal field, keeps `allowed_values` next to the prompt) — all resolve correctly.

Also stripped pre-existing trailing whitespace in `routers/connectors.py` (the flake8 pre-commit hook fails on the file otherwise) and documented `prompt` + `allowed_values` in the endpoint docstring so they show in the OpenAPI schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbBYBEcgRVGXiZiq7kLDBv