### PR TITLE
Add onchain_executor: on-chain actions through the Aomi Pipeline (stage → simulate → commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ receipt balance is shown separately and is never divided between controllers.
 Unknown submission outcomes remain unresolved, duplicate receipts count once,
 and storage or balance-read failures return 503 instead of an empty portfolio.
 
+Simulation estimates are exposed as `custom_info.estimated_gas_quote`, separately from incurred fees. Receipt-derived quote fees are currently unavailable (`fees_quote_source: unavailable`); the executor does not book simulated gas into trading fee totals.
+
 `max_gas_quote` checks estimated execution gas in USDT using the market-data
 price pool. Missing pricing stops a bounded request. This is an estimate, not a
 signer-enforced fee cap; it excludes rollup data fees and provider surcharges.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,33 @@ make tailscale-status     # Check tailnet peers
 ```
 Confirm the node appears in `tailscale status` and that MagicDNS is enabled in your Tailscale admin console.
 
+## Aomi on-chain executors
+
+`onchain_executor` runs a transaction bundle through Aomi's stage, simulate and
+commit lifecycle. Configure `AOMI_URL` and either `AOMI_TOKEN_FILE` or
+`AOMI_TOKEN`; the Aomi account owns the signer. A Hummingbot exchange connector
+or Gateway wallet is not required. PostgreSQL is required: creation is saved
+before the executor starts, and failed completion writes retain the live result
+for retry.
+
+For Aave V3, `mode: "lending"` takes an exact `lending` plan containing
+`chain_id`, `wallet`, `pool`, `asset`, `action` (`supply` or `withdraw`) and
+`amount` in raw token units. The executor verifies every staged call against
+that plan before committing. Use `commit: false` to preview first. A pending
+wallet-signature response is not reported as a confirmed transaction.
+
+`GET /executors/lending/positions` reconstructs controller contributions from
+durable executor history and reads the wallet's current receipt-token balance
+for the supported Base USDC/Aave market. It reports raw amounts as strings.
+Contributions are not current asset balances or profit; a shared wallet's
+receipt balance is shown separately and is never divided between controllers.
+Unknown submission outcomes remain unresolved, duplicate receipts count once,
+and storage or balance-read failures return 503 instead of an empty portfolio.
+
+`max_gas_quote` checks estimated execution gas in USDT using the market-data
+price pool. Missing pricing stops a bounded request. This is an estimate, not a
+signer-enforced fee cap; it excludes rollup data fees and provider surcharges.
+
 ## Support
 
 - **Docs**: https://hummingbot.org/hummingbot-api/

--- a/README.md
+++ b/README.md
@@ -363,3 +363,53 @@ signer-enforced fee cap; it excludes rollup data fees and provider surcharges.
 - **Tailscale guide**: https://hummingbot.org/hummingbot-api/tailscale/
 - **API Docs**: http://localhost:8000/docs
 - **Issues**: https://github.com/hummingbot/hummingbot-api/issues
+
+### Operator lending allocation policy
+
+Set `AOMI_LENDING_POLICY_FILE` on every API process sharing the executor database to
+an operator-owned JSON file. The API re-reads it at admission. A missing or invalid
+configured file refuses committed on-chain creates. Keep this file outside agent
+writable configuration. An example (amounts are raw USDC units, six decimals):
+
+```json
+{
+  "wallet": "0xYOUR_AOMI_SIGNING_WALLET",
+  "account_name": "master_account",
+  "controller_limits_raw": {"reserves-agent": "100000000"},
+  "max_total_supply_raw": "100000000",
+  "max_action_raw": "50000000",
+  "max_gas_quote": "1"
+}
+```
+
+Replace the wallet placeholder with the actual signer. The supported market is
+Base USDC at Aave V3. While configured, all committed on-chain creates must be
+exact lending plans for that wallet and a granted controller. The total limit
+covers recorded net contributions and pending supplies across controllers and
+Hummingbot accounts using that wallet. It is not a USDT market valuation or a cap
+on externally supplied capital, accrued interest, losses, or other trading exposure.
+Withdrawals are limited to the controller's confirmed contributions minus pending
+withdrawals; pending deposits cannot fund withdrawals. Only confirmed withdrawals
+release capacity. Historical raw/operation commits require reconciliation before
+activating this policy because their lending effects cannot be reconstructed.
+
+Admission acquires a PostgreSQL transaction lock, reads full durable history,
+validates the grant, and inserts the pending executor record in the same transaction.
+The executor starts only after commit. Concurrent API processes and process restarts
+therefore see the same reservation. An unknown result continues to reserve capacity;
+operators must reconcile it against actual receipts, not delete history to free limits.
+A policy edit applies to new admissions, not actions already admitted.
+
+`GET /executors/lending/policy` exposes the active grant to authenticated callers.
+Automatic clients must set `require_lending_policy: true`: this prevents a policy
+removed between preview and creation from falling back to unrestricted manual mode.
+Condor's automatic gate remains disabled until its grant and valuation checks are
+connected; this API feature alone does not enable unattended execution.
+
+The real PostgreSQL race/restart regression runs with an isolated local database
+whose name starts `hummingbot_policy_check_`:
+
+```bash
+AOMI_POLICY_TEST_DATABASE_URL=postgresql+asyncpg://USER@127.0.0.1:PORT/hummingbot_policy_check_test \
+  pytest -q test/test_lending_policy_admission.py
+```

--- a/README.md
+++ b/README.md
@@ -403,8 +403,12 @@ A policy edit applies to new admissions, not actions already admitted.
 `GET /executors/lending/policy` exposes the active grant to authenticated callers.
 Automatic clients must set `require_lending_policy: true`: this prevents a policy
 removed between preview and creation from falling back to unrestricted manual mode.
-Condor's automatic gate remains disabled until its grant and valuation checks are
-connected; this API feature alone does not enable unattended execution.
+Condor PR #232 connects its automatic gate to this grant, durable contribution
+history, and an independent USDC/USDT market quote. A named agent must explicitly
+request the enforced policy, and normal portfolio risk limits still apply.
+The local fork integration check completed a granted supply and withdrawal through
+Condor's risk callback and MCP tool, and refused an over-limit request. This used
+an explicitly bounded Anvil test signer; it does not certify production signing.
 
 The real PostgreSQL race/restart regression runs with an isolated local database
 whose name starts `hummingbot_policy_check_`:

--- a/README.md
+++ b/README.md
@@ -370,6 +370,45 @@ Simulation estimates are exposed as `custom_info.estimated_gas_quote`, separatel
 price pool. Missing pricing stops a bounded request. This is an estimate, not a
 signer-enforced fee cap; it excludes rollup data fees and provider surcharges.
 
+### Solana market preparation
+
+Set `AOMI_PREPARATION_APPLICATION_ID` to the positive ID of the registered
+`solana-defi` Aomi application. The Aomi deployment must have that application's
+active release artifact and its preparation service configured. An app name
+alone does not select a verified release. Leaving the ID unset disables this
+preparation endpoint without disabling other executors.
+
+`POST /executors/onchain/prepare` accepts `operation` (`venues`, `market`,
+`position`, or `prepare`) and an `arguments` object. Hummingbot binds market,
+position and preparation requests to the connected Aomi Solana wallet; callers
+cannot choose another application's ID or a different RPC endpoint. The response
+contains unsigned instructions and market data, never a staged Build or a
+transaction submission.
+
+Submit the returned batches through the shared `onchain_executor` in SVM
+instruction mode to simulate them. Confirmation should retain the exact
+`reviewed_svm_plan_hash` from the preview and an explicit
+`max_svm_network_fee_lamports`. These bind the reviewed instructions and check
+complete simulated network fees; they do not constitute an unattended spending
+grant. Venue-specific SDK recipes run inside Aomi, so supporting these markets
+does not require separate Hummingbot venue connectors.
+
+`svm_spending_policy` adds a wallet, market account, protocol program, allowed
+top-level programs and a map of `max_debits_raw` keyed by mint (or `native` for
+SOL). Every observed outgoing wallet asset must be listed. Limits use unsigned
+raw integer strings, require a native limit, and do not subtract credits from
+other accounts or other balance rows. The selected market must occur in the
+selected protocol's staged instructions. A passing simulation with incomplete
+balance snapshots still refuses the policy before wallet handoff.
+
+These limits apply to final per-account net balance changes in one simulated
+transaction. They do not bound intermediate transfers, future execution state,
+approval authority or off-wallet economic exposure such as staked positions.
+Multi-transaction previews cannot certify a sequential budget and are refused
+when this policy is set. RPC fallback and unsupported token account layouts
+remain incomplete for this check. Use the exact reviewed plan hash when confirming;
+this policy is not an unattended grant or an on-chain spending restriction.
+
 ## Support
 
 - **Docs**: https://hummingbot.org/hummingbot-api/

--- a/README.md
+++ b/README.md
@@ -397,8 +397,8 @@ does not require separate Hummingbot venue connectors.
 top-level programs and a map of `max_debits_raw` keyed by mint (or `native` for
 SOL). Every observed outgoing wallet asset must be listed. Limits use unsigned
 raw integer strings, require a native limit, and do not subtract credits from
-other accounts or other balance rows. The selected market must occur in the
-selected protocol's staged instructions. A passing simulation with incomplete
+other accounts or other balance rows. Every staged instruction for the selected protocol must reference the selected
+market. A passing simulation with incomplete
 balance snapshots still refuses the policy before wallet handoff.
 
 These limits apply to final per-account net balance changes in one simulated

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import logging
-from typing import List
+from pathlib import Path
+from typing import Callable, List
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -155,6 +156,41 @@ class GatewaySettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="GATEWAY_", extra="ignore")
 
 
+class AomiSettings(BaseSettings):
+    """Aomi Pipeline API configuration, used by the onchain_executor.
+
+    The bearer can be given inline (AOMI_TOKEN) or as a file path (AOMI_TOKEN_FILE). The file is
+    re-read on every request, so a rotated token takes effect without a restart.
+    """
+
+    url: str = Field(default="https://chat.aomi.dev", description="Aomi origin serving /v1/pipeline")
+    token: str = Field(default="", description="Bearer token with pipeline:execute (and custody:delegate to commit)")
+    token_file: str = Field(
+        default="",
+        description="Path to a file holding the bearer token; takes precedence over AOMI_TOKEN when set"
+    )
+    timeout: float = Field(default=30.0, description="Per-request HTTP timeout in seconds")
+
+    model_config = SettingsConfigDict(env_prefix="AOMI_", extra="ignore")
+
+    @property
+    def configured(self) -> bool:
+        """Whether any bearer source is set."""
+        return bool(self.token or self.token_file)
+
+    def token_provider(self) -> Callable[[], str]:
+        """A zero-arg callable the PipelineClient can pull the current bearer from."""
+        token_file = self.token_file
+        token = self.token
+
+        def _provide() -> str:
+            if token_file:
+                return Path(token_file).read_text(encoding="utf-8").strip()
+            return token
+
+        return _provide
+
+
 class CORSSettings(BaseSettings):
     """CORS configuration for the API (SEC-019).
 
@@ -239,6 +275,7 @@ class Settings(BaseSettings):
     security: SecuritySettings = Field(default_factory=SecuritySettings)
     aws: AWSSettings = Field(default_factory=AWSSettings)
     gateway: GatewaySettings = Field(default_factory=GatewaySettings)
+    aomi: AomiSettings = Field(default_factory=AomiSettings)
     cors: CORSSettings = Field(default_factory=CORSSettings)
     app: AppSettings = Field(default_factory=AppSettings)
     backtesting: BacktestingSettings = Field(default_factory=BacktestingSettings)

--- a/config.py
+++ b/config.py
@@ -171,6 +171,10 @@ class AomiSettings(BaseSettings):
     )
     timeout: float = Field(default=30.0, description="Per-request HTTP timeout in seconds")
 
+    lending_policy_file: str = Field(
+        default="", description="Operator-owned JSON lending allocation policy; empty disables automatic grants"
+    )
+
     model_config = SettingsConfigDict(env_prefix="AOMI_", extra="ignore")
 
     @property

--- a/config.py
+++ b/config.py
@@ -186,6 +186,10 @@ class AomiSettings(BaseSettings):
         description="Path to a file holding the bearer token; takes precedence over AOMI_TOKEN when set"
     )
     timeout: float = Field(default=30.0, description="Per-request HTTP timeout in seconds")
+    preparation_application_id: int | None = Field(
+        default=None, gt=0,
+        description="Registered solana-defi application ID; required for market preparation"
+    )
 
     lending_policy_file: str = Field(
         default="", description="Operator-owned JSON lending allocation policy; empty disables automatic grants"

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,9 @@ dependencies:
       # refuses to start against a core that is missing them, so a wrong install is a
       # startup error rather than a deployment that books zeros in silence.
       - hummingbot
+      # Aomi Pipeline client for the onchain_executor. Local development against a checkout
+      # installs it editable instead: pip install -e ../aomi-python
+      - aomi @ git+https://github.com/aomi-labs/aomi-python
       - geckoterminal-py>=0.3.1
       - msgpack>=1.0.5
       - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
       - hummingbot
       # Aomi Pipeline client for the onchain_executor. Local development against a checkout
       # installs it editable instead: pip install -e ../aomi-python
-      - aomi @ git+https://github.com/aomi-labs/aomi-python
+      - aomi @ git+https://github.com/aomi-labs/aomi-python@b5c8ab20a3f516f9d2854403f3993c309b3dcec2
       - geckoterminal-py>=0.3.1
       - msgpack>=1.0.5
       - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
       - hummingbot
       # Aomi Pipeline client for the onchain_executor. Local development against a checkout
       # installs it editable instead: pip install -e ../aomi-python
-      - aomi @ git+https://github.com/aomi-labs/aomi-python@b108c2d5399ac1d3a31a98f4b6668b3b20233d8e
+      - aomi @ git+https://github.com/aomi-labs/aomi-python@caa72d5225dd60e482835e0341a91293d7549dd3
       - geckoterminal-py>=0.3.1
       - msgpack>=1.0.5
       - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
       - hummingbot
       # Aomi Pipeline client for the onchain_executor. Local development against a checkout
       # installs it editable instead: pip install -e ../aomi-python
-      - aomi @ git+https://github.com/aomi-labs/aomi-python@b5c8ab20a3f516f9d2854403f3993c309b3dcec2
+      - aomi @ git+https://github.com/aomi-labs/aomi-python@b108c2d5399ac1d3a31a98f4b6668b3b20233d8e
       - geckoterminal-py>=0.3.1
       - msgpack>=1.0.5
       - flake8

--- a/models/executors.py
+++ b/models/executors.py
@@ -235,6 +235,7 @@ EXECUTOR_TYPES = Literal[
     "xemm_executor",
     "order_executor",
     "lp_executor",
+    "onchain_executor",
 ]
 
 
@@ -285,6 +286,28 @@ class CreateExecutorRequest(BaseModel):
                             "side": "BUY",
                             "extra_params": {"strategyType": 0},
                             "keep_position": False
+                        }
+                    }
+                },
+                {
+                    "summary": "Onchain Executor",
+                    "description": "Stage, simulate and commit a 0-value transfer on Base through the Aomi Pipeline "
+                                   "(put your own wallet in 'to' for a self-transfer)",
+                    "value": {
+                        "account_name": "master_account",
+                        "executor_config": {
+                            "type": "onchain_executor",
+                            "chain_id": 8453,
+                            "mode": "calls",
+                            "calls": [
+                                {
+                                    "to": "0x0000000000000000000000000000000000000000",
+                                    "value": "0",
+                                    "data": {"signature": "", "args": [], "raw": ""},
+                                    "description": "0-value self-transfer"
+                                }
+                            ],
+                            "commit": True
                         }
                     }
                 }

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -35,6 +35,19 @@ NATIVE_SYMBOLS: Dict[int, str] = {
 PIPELINE_PREFIX = "/v1/pipeline"
 
 
+def _reject_reason(operation: str) -> Optional[str]:
+    """Why the Aomi policy refuses this operation as a build target, or None.
+
+    Harness plumbing (authorization, scheduling, threads), the raw stage/simulate/commit
+    primitives, reads, and test fixtures are never valid executor operations.
+    """
+    try:
+        from aomi.pipeline import policy
+    except ImportError:  # the client ships it; without the client nothing runs anyway
+        return None
+    return policy.reject_reason(operation)
+
+
 def chain_name(chain: str, chain_id: int) -> str:
     return CHAIN_NAMES.get(chain_id, f"{chain}-{chain_id}")
 
@@ -107,6 +120,9 @@ class OnchainExecutorConfig(ExecutorConfigBase):
                 raise ValueError("mode 'operation' requires 'operation'")
             if self.calls is not None:
                 raise ValueError("mode 'operation' does not take 'calls'")
+            reason = _reject_reason(self.operation.rsplit("/", 1)[-1])
+            if reason:
+                raise ValueError(f"operation cannot be built by this executor: {reason}")
         else:
             if not self.calls:
                 raise ValueError("mode 'calls' requires a non-empty 'calls' list")
@@ -130,9 +146,16 @@ class OnchainExecutorConfig(ExecutorConfigBase):
 
     @property
     def operation_path(self) -> Optional[str]:
-        """The pipeline path for ``operation``: a bare name resolves into the app catalog."""
+        """The pipeline path for ``operation``.
+
+        A bare name resolves into the named app's catalog. When the app is left at ``default``
+        and exactly one skill is named, it resolves into that skill instead, which is where
+        protocol operations such as Aave or Morpho live.
+        """
         if not self.operation:
             return None
         if self.operation.startswith("/"):
             return self.operation
+        if self.app == "default" and len(self.skills) == 1:
+            return f"{PIPELINE_PREFIX}/skills/{self.skills[0]}/operations/{self.operation}"
         return f"{PIPELINE_PREFIX}/apps/{self.app}/operations/{self.operation}"

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -1,0 +1,138 @@
+"""Configuration for the onchain_executor.
+
+An onchain executor runs one Aomi Pipeline lifecycle -- stage (or build), simulate, commit --
+for a single on-chain transaction bundle. It has no exchange connector: the chain is named by
+``chain_id`` and the bundle is either a catalog operation (``mode="operation"``) or a list of
+raw calls (``mode="calls"``).
+
+``connector_name`` and ``trading_pair`` exist because the executors table requires them; both
+are derived from ``chain_id`` when not given so the executor records like any other.
+"""
+import time
+from decimal import Decimal
+from typing import Any, Dict, List, Literal, Optional
+
+from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
+from pydantic import Field, model_validator
+
+# chain_id -> connector_name used for the executors table and the API listing.
+CHAIN_NAMES: Dict[int, str] = {
+    1: "ethereum",
+    10: "optimism",
+    56: "bsc",
+    137: "polygon",
+    8453: "base",
+    42161: "arbitrum",
+    59144: "linea",
+}
+
+# chain_id -> native gas token symbol; ETH unless the chain says otherwise.
+NATIVE_SYMBOLS: Dict[int, str] = {
+    137: "POL",
+    56: "BNB",
+}
+
+PIPELINE_PREFIX = "/v1/pipeline"
+
+
+def chain_name(chain: str, chain_id: int) -> str:
+    return CHAIN_NAMES.get(chain_id, f"{chain}-{chain_id}")
+
+
+def native_symbol(chain_id: int) -> str:
+    return NATIVE_SYMBOLS.get(chain_id, "ETH")
+
+
+class OnchainExecutorConfig(ExecutorConfigBase):
+    """Run one on-chain transaction bundle through the Aomi Pipeline (stage, simulate, commit)."""
+
+    type: Literal["onchain_executor"] = "onchain_executor"
+    connector_name: str = Field(
+        default="",
+        description="Chain name for record keeping (derived from chain_id when empty, e.g. 'base'); no connector is used"
+    )
+    trading_pair: str = Field(
+        default="",
+        description="Pair for record keeping (derived as '<native>-<native>' when empty, e.g. 'ETH-ETH')"
+    )
+    chain: Literal["evm", "svm"] = Field(default="evm", description="Chain family the bundle targets")
+    chain_id: int = Field(..., ge=1, description="EVM chain id (1 ethereum, 10 optimism, 8453 base, 42161 arbitrum, ...)")
+    mode: Literal["operation", "calls"] = Field(
+        ...,
+        description="'operation' builds the bundle from an app/skill catalog operation; 'calls' stages raw EVM calls"
+    )
+    app: str = Field(default="default", description="Aomi app whose catalog and skills the pipeline uses")
+    skills: List[str] = Field(default_factory=list, description="Skills to load alongside the app")
+    operation: Optional[str] = Field(
+        default=None,
+        description="operation mode: operation name in the app catalog, or an absolute /v1/pipeline/... path"
+    )
+    arguments: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="operation mode: arguments for the operation, as its input schema describes them"
+    )
+    calls: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="calls mode: evm_stage_tx argument maps ({to, value, data: {signature, args, raw}, description, ...}); "
+                    "chain_id is filled in from the config when a call omits it"
+    )
+    notional_quote: Optional[Decimal] = Field(
+        default=None,
+        description="Notional value of the bundle in quote currency, for the caller's own risk accounting (not enforced here)"
+    )
+    max_gas_quote: Optional[Decimal] = Field(
+        default=None,
+        gt=0,
+        description="Refuse to commit when the simulated gas cost, priced in quote currency, exceeds this"
+    )
+    keep_position: bool = Field(
+        default=False,
+        description="Reported back in custom_info for the caller; an on-chain bundle has no position to unwind"
+    )
+    timeout_sec: int = Field(
+        default=120,
+        ge=5,
+        le=3600,
+        description="Seconds allowed to reach the commit; the executor fails if staging/simulation takes longer"
+    )
+    commit: bool = Field(
+        default=True,
+        description="Commit after a passing simulation; False stops after simulation (dry run)"
+    )
+
+    @model_validator(mode="after")
+    def _check_mode_and_derive(self):
+        if self.mode == "operation":
+            if not self.operation:
+                raise ValueError("mode 'operation' requires 'operation'")
+            if self.calls is not None:
+                raise ValueError("mode 'operation' does not take 'calls'")
+        else:
+            if not self.calls:
+                raise ValueError("mode 'calls' requires a non-empty 'calls' list")
+            if self.operation is not None or self.arguments is not None:
+                raise ValueError("mode 'calls' does not take 'operation' or 'arguments'")
+            if self.chain == "svm":
+                raise ValueError("mode 'calls' stages EVM calls; use mode 'operation' for svm")
+            self.calls = [
+                call if call.get("chain_id") is not None else {**call, "chain_id": self.chain_id}
+                for call in self.calls
+            ]
+        if self.timestamp is None:
+            # The base validator only fills this when the field is passed; ExecutorInfo needs a float.
+            self.timestamp = time.time()
+        if not self.connector_name:
+            self.connector_name = chain_name(self.chain, self.chain_id)
+        if not self.trading_pair:
+            symbol = native_symbol(self.chain_id)
+            self.trading_pair = f"{symbol}-{symbol}"
+        return self
+
+    @property
+    def operation_path(self) -> Optional[str]:
+        """The pipeline path for ``operation``: a bare name resolves into the app catalog."""
+        if not self.operation:
+            return None
+        if self.operation.startswith("/"):
+            return self.operation
+        return f"{PIPELINE_PREFIX}/apps/{self.app}/operations/{self.operation}"

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -69,7 +69,10 @@ class OnchainExecutorConfig(ExecutorConfigBase):
         description="Pair for record keeping (derived as '<native>-<native>' when empty, e.g. 'ETH-ETH')"
     )
     chain: Literal["evm", "svm"] = Field(default="evm", description="Chain family the bundle targets")
-    chain_id: int = Field(..., ge=1, description="EVM chain id (1 ethereum, 10 optimism, 8453 base, 42161 arbitrum, ...)")
+    chain_id: int = Field(
+        ..., ge=1, description="EVM chain id (1 ethereum, 10 optimism, 8453 base, 42161 arbitrum, ...); pass 1 for svm"
+    )
+    cluster: str = Field(default="mainnet-beta", description="svm only: Solana cluster the bundle targets")
     mode: Literal["operation", "calls"] = Field(
         ...,
         description="'operation' builds the bundle from an app/skill catalog operation; 'calls' stages raw EVM calls"
@@ -138,9 +141,9 @@ class OnchainExecutorConfig(ExecutorConfigBase):
             # The base validator only fills this when the field is passed; ExecutorInfo needs a float.
             self.timestamp = time.time()
         if not self.connector_name:
-            self.connector_name = chain_name(self.chain, self.chain_id)
+            self.connector_name = f"solana-{self.cluster}" if self.chain == "svm" else chain_name(self.chain, self.chain_id)
         if not self.trading_pair:
-            symbol = native_symbol(self.chain_id)
+            symbol = "SOL" if self.chain == "svm" else native_symbol(self.chain_id)
             self.trading_pair = f"{symbol}-{symbol}"
         return self
 

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -83,6 +83,9 @@ class OnchainExecutorConfig(ExecutorConfigBase):
     lending: Optional[LendingPlan] = Field(
         default=None, description="Exact Aave V3 supply or withdrawal plan, with amounts in raw token units"
     )
+    require_lending_policy: bool = Field(
+        default=False, description="Require an active operator lending grant; intended for automatic agent submissions"
+    )
     app: str = Field(default="default", description="Aomi app whose catalog and skills the pipeline uses")
     skills: List[str] = Field(default_factory=list, description="Skills to load alongside the app")
     operation: Optional[str] = Field(

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -16,6 +16,8 @@ from aomi.pipeline.lending import LendingPlan
 from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
 from pydantic import Field, model_validator
 
+from models.svm_policy import SvmSpendingPolicy
+
 # chain_id -> connector_name used for the executors table and the API listing.
 CHAIN_NAMES: Dict[int, str] = {
     1: "ethereum",
@@ -75,10 +77,15 @@ class OnchainExecutorConfig(ExecutorConfigBase):
         ..., ge=1, description="EVM chain id (1 ethereum, 10 optimism, 8453 base, 42161 arbitrum, ...); pass 1 for svm"
     )
     cluster: str = Field(default="mainnet-beta", description="svm only: Solana cluster the bundle targets")
-    mode: Literal["operation", "calls", "lending"] = Field(
+    mode: Literal["operation", "calls", "instructions", "lending"] = Field(
         ...,
         description="'operation' builds a catalog operation; 'calls' stages raw EVM calls; "
-                    "'lending' verifies an exact Aave V3 plan"
+                    "'instructions' stages Solana instruction batches; 'lending' verifies an exact Aave V3 plan"
+    )
+    instructions: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="instructions mode: svm_stage_ix argument batches, each containing a description and "
+                    "instructions list; accepts IDL encode or raw data_base64, accounts and lookup tables"
     )
     lending: Optional[LendingPlan] = Field(
         default=None, description="Exact Aave V3 supply or withdrawal plan, with amounts in raw token units"
@@ -110,6 +117,20 @@ class OnchainExecutorConfig(ExecutorConfigBase):
         gt=0,
         description="Gas ceiling in USDT; refuse to commit if simulated gas exceeds it or cannot be priced"
     )
+    max_svm_network_fee_lamports: Optional[int] = Field(
+        default=None, ge=0, strict=True,
+        description="Solana only: ceiling for the complete simulated network fee in lamports; "
+                    "missing fee evidence refuses submission. Excludes rent, protocol and signer charges."
+    )
+    reviewed_svm_plan_hash: Optional[str] = Field(
+        default=None, pattern=r"^[0-9a-f]{64}$", strict=True,
+        description="Instructions mode: plan hash from the operator's preview. Refuse changed "
+                    "wallet, cluster, programs, accounts, instruction data or assembly options."
+    )
+    svm_spending_policy: Optional[SvmSpendingPolicy] = Field(
+        default=None,
+        description="Operator wallet, venue and simulated asset debit limits; requires complete balance evidence"
+    )
     keep_position: bool = Field(
         default=False,
         description="Reported back in custom_info for the caller; an on-chain bundle has no position to unwind"
@@ -127,7 +148,23 @@ class OnchainExecutorConfig(ExecutorConfigBase):
 
     @model_validator(mode="after")
     def _check_mode_and_derive(self):
-        if self.mode == "lending":
+        if self.svm_spending_policy is not None and (self.chain != "svm" or self.mode != "instructions"):
+            raise ValueError("svm_spending_policy requires svm instructions mode")
+        if self.max_svm_network_fee_lamports is not None and self.chain != "svm":
+            raise ValueError("max_svm_network_fee_lamports requires svm")
+        if self.reviewed_svm_plan_hash is not None and (self.chain != "svm" or self.mode != "instructions"):
+            raise ValueError("reviewed_svm_plan_hash requires svm instructions mode")
+        if self.mode == "instructions":
+            if self.chain != "svm" or not self.instructions:
+                raise ValueError("instructions mode requires non-empty instructions on svm")
+            if any(value is not None for value in (self.calls, self.operation, self.arguments, self.lending)):
+                raise ValueError("instructions mode takes only instruction batches")
+            for batch in self.instructions:
+                if not isinstance(batch.get("instructions"), list) or not batch["instructions"]:
+                    raise ValueError("each instruction batch requires a non-empty instructions list")
+        elif self.instructions is not None:
+            raise ValueError("instruction batches require instructions mode")
+        elif self.mode == "lending":
             if self.lending is None or self.chain != "evm" or self.chain_id != self.lending.chain_id:
                 raise ValueError("lending mode requires a plan on the configured EVM chain")
             if self.calls is not None or self.operation is not None or self.arguments is not None:

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -12,6 +12,7 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, List, Literal, Optional
 
+from aomi.pipeline.lending import LendingPlan
 from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
 from pydantic import Field, model_validator
 
@@ -62,7 +63,8 @@ class OnchainExecutorConfig(ExecutorConfigBase):
     type: Literal["onchain_executor"] = "onchain_executor"
     connector_name: str = Field(
         default="",
-        description="Chain name for record keeping (derived from chain_id when empty, e.g. 'base'); no connector is used"
+        description="Chain name for record keeping (derived from chain_id when empty, e.g. 'base'); "
+                    "no connector is used"
     )
     trading_pair: str = Field(
         default="",
@@ -73,9 +75,13 @@ class OnchainExecutorConfig(ExecutorConfigBase):
         ..., ge=1, description="EVM chain id (1 ethereum, 10 optimism, 8453 base, 42161 arbitrum, ...); pass 1 for svm"
     )
     cluster: str = Field(default="mainnet-beta", description="svm only: Solana cluster the bundle targets")
-    mode: Literal["operation", "calls"] = Field(
+    mode: Literal["operation", "calls", "lending"] = Field(
         ...,
-        description="'operation' builds the bundle from an app/skill catalog operation; 'calls' stages raw EVM calls"
+        description="'operation' builds a catalog operation; 'calls' stages raw EVM calls; "
+                    "'lending' verifies an exact Aave V3 plan"
+    )
+    lending: Optional[LendingPlan] = Field(
+        default=None, description="Exact Aave V3 supply or withdrawal plan, with amounts in raw token units"
     )
     app: str = Field(default="default", description="Aomi app whose catalog and skills the pipeline uses")
     skills: List[str] = Field(default_factory=list, description="Skills to load alongside the app")
@@ -89,7 +95,7 @@ class OnchainExecutorConfig(ExecutorConfigBase):
     )
     calls: Optional[List[Dict[str, Any]]] = Field(
         default=None,
-        description="calls mode: evm_stage_tx argument maps ({to, value, data: {signature, args, raw}, description, ...}); "
+        description="calls mode: evm_stage_tx maps ({to, value, data: {signature, args, raw}, description, ...}); "
                     "chain_id is filled in from the config when a call omits it"
     )
     notional_quote: Optional[Decimal] = Field(
@@ -118,7 +124,14 @@ class OnchainExecutorConfig(ExecutorConfigBase):
 
     @model_validator(mode="after")
     def _check_mode_and_derive(self):
-        if self.mode == "operation":
+        if self.mode == "lending":
+            if self.lending is None or self.chain != "evm" or self.chain_id != self.lending.chain_id:
+                raise ValueError("lending mode requires a plan on the configured EVM chain")
+            if self.calls is not None or self.operation is not None or self.arguments is not None:
+                raise ValueError("lending mode takes only a lending plan")
+        elif self.lending is not None:
+            raise ValueError("lending plan requires lending mode")
+        elif self.mode == "operation":
             if not self.operation:
                 raise ValueError("mode 'operation' requires 'operation'")
             if self.calls is not None:
@@ -141,7 +154,9 @@ class OnchainExecutorConfig(ExecutorConfigBase):
             # The base validator only fills this when the field is passed; ExecutorInfo needs a float.
             self.timestamp = time.time()
         if not self.connector_name:
-            self.connector_name = f"solana-{self.cluster}" if self.chain == "svm" else chain_name(self.chain, self.chain_id)
+            self.connector_name = (
+                f"solana-{self.cluster}" if self.chain == "svm" else chain_name(self.chain, self.chain_id)
+            )
         if not self.trading_pair:
             symbol = "SOL" if self.chain == "svm" else native_symbol(self.chain_id)
             self.trading_pair = f"{symbol}-{symbol}"

--- a/models/onchain_executor.py
+++ b/models/onchain_executor.py
@@ -94,12 +94,12 @@ class OnchainExecutorConfig(ExecutorConfigBase):
     )
     notional_quote: Optional[Decimal] = Field(
         default=None,
-        description="Notional value of the bundle in quote currency, for the caller's own risk accounting (not enforced here)"
+        description="Notional value of the bundle in USDT, for the caller's own risk accounting (not enforced here)"
     )
     max_gas_quote: Optional[Decimal] = Field(
         default=None,
         gt=0,
-        description="Refuse to commit when the simulated gas cost, priced in quote currency, exceeds this"
+        description="Gas ceiling in USDT; refuse to commit if simulated gas exceeds it or cannot be priced"
     )
     keep_position: bool = Field(
         default=False,

--- a/models/onchain_preparation.py
+++ b/models/onchain_preparation.py
@@ -1,0 +1,10 @@
+"""Read-only Aomi preparation requests shared by all supported Solana venues."""
+from typing import Any, Dict, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OnchainPreparationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    operation: Literal["venues", "market", "prepare", "position"]
+    arguments: Dict[str, Any] = Field(default_factory=dict)

--- a/models/svm_policy.py
+++ b/models/svm_policy.py
@@ -1,0 +1,82 @@
+"""Operator limits for one simulated Solana transaction, before wallet handoff."""
+from typing import Dict, List
+
+from aomi.pipeline import Build
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SvmSpendingPolicy(BaseModel):
+    wallet: str = Field(min_length=1, strict=True)
+    market: str = Field(min_length=1, strict=True)
+    protocol_program: str = Field(min_length=1, strict=True)
+    allowed_programs: List[str] = Field(min_length=1)
+    max_debits_raw: Dict[str, str] = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_limits(self):
+        if self.protocol_program not in self.allowed_programs:
+            raise ValueError("The selected protocol must be an allowed program")
+        if len(set(self.allowed_programs)) != len(self.allowed_programs) or any(not p for p in self.allowed_programs):
+            raise ValueError("Allowed programs must be nonempty and unique")
+        if "native" not in self.max_debits_raw:
+            raise ValueError("Include a native SOL debit ceiling for network fees and account funding")
+        for asset, amount in self.max_debits_raw.items():
+            if not asset or not amount or not amount.isascii() or not amount.isdecimal() or len(amount) > 20:
+                raise ValueError("Debit limits must be unsigned raw integer strings keyed by asset")
+            if int(amount) > 2**64 - 1:
+                raise ValueError("Debit limit exceeds u64")
+        return self
+
+    def verify(self, build: Build, cluster: str) -> Dict[str, str]:
+        """Cap observed per-account net debits; do not offset them with other credits.
+
+        This is a preflight policy, not an on-chain spending grant. A complete
+        balance-evidence guard is mandatory; missing rows never imply completeness.
+        Independent multi-transaction simulations cannot prove a sequential budget.
+        """
+        simulation = build.simulation
+        if build.chain != "svm" or build.from_address != self.wallet or not build.actions:
+            raise ValueError("Spending policy wallet or chain differs from the staged plan")
+        found_market = False
+        for action in build.actions:
+            instruction = action.get("instruction") if isinstance(action, dict) else None
+            if not isinstance(instruction, dict) or action.get("lane") != "instruction":
+                raise ValueError("Spending policy requires explicit instruction actions")
+            if instruction.get("payer") != self.wallet or instruction.get("cluster") != cluster:
+                raise ValueError("Staged wallet or network differs from the spending policy")
+            program = instruction.get("program_id")
+            if program not in self.allowed_programs:
+                raise ValueError("Staged instruction uses a program outside the reviewed venue policy")
+            accounts = instruction.get("accounts")
+            if not isinstance(accounts, list) or any(not isinstance(a, dict) for a in accounts):
+                raise ValueError("Staged account evidence is malformed")
+            if program == self.protocol_program and any(a.get("pubkey") == self.market for a in accounts):
+                found_market = True
+        if not found_market:
+            raise ValueError("Selected market is absent from the selected protocol's instructions")
+        if simulation is None or not simulation.passed:
+            raise ValueError("Spending policy requires a successful simulation")
+        guards = [g for g in simulation.guards if isinstance(g, dict) and g.get("name") == "svm_balance_changes"]
+        if len(guards) != 1 or guards[0].get("status") != "passed":
+            raise ValueError("Complete Solana balance evidence is unavailable")
+        fee_guards = [g for g in simulation.guards if isinstance(g, dict) and g.get("name") == "svm_network_fees"]
+        if len(fee_guards) != 1 or fee_guards[0].get("status") != "passed" or len(simulation.fees) != 1:
+            raise ValueError("Spending policy requires a single simulated transaction")
+        totals: Dict[str, int] = {}
+        for row in simulation.balance_changes:
+            if row.cluster != cluster or type(row.step) is not int or row.step != 0 or not row.account or not row.asset:
+                raise ValueError("Simulation balance identity is incomplete")
+            if row.direction not in ("in", "out") or row.amount is None or not row.amount.isascii() or not row.amount.isdecimal():
+                raise ValueError("Simulation balance amount is malformed")
+            if len(row.amount) > 20 or int(row.amount) > 2**64 - 1:
+                raise ValueError("Simulation balance amount exceeds u64")
+            if row.account != self.wallet or row.direction != "out":
+                continue
+            if row.asset not in self.max_debits_raw:
+                raise ValueError("Simulation debits a wallet asset outside the spending policy")
+            totals[row.asset] = totals.get(row.asset, 0) + int(row.amount)
+            if totals[row.asset] > int(self.max_debits_raw[row.asset]):
+                raise ValueError(f"Simulated debit exceeds the operator limit for {row.asset}")
+        return {asset: str(totals.get(asset, 0)) for asset in self.max_debits_raw}

--- a/models/svm_policy.py
+++ b/models/svm_policy.py
@@ -52,7 +52,9 @@ class SvmSpendingPolicy(BaseModel):
             accounts = instruction.get("accounts")
             if not isinstance(accounts, list) or any(not isinstance(a, dict) for a in accounts):
                 raise ValueError("Staged account evidence is malformed")
-            if program == self.protocol_program and any(a.get("pubkey") == self.market for a in accounts):
+            if program == self.protocol_program:
+                if not any(a.get("pubkey") == self.market for a in accounts):
+                    raise ValueError("Every selected-protocol instruction must reference the selected market")
                 found_market = True
         if not found_market:
             raise ValueError("Selected market is absent from the selected protocol's instructions")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,11 @@ build-backend = "setuptools.build_meta"
 line-length = 130
 target-version = ["py38"]
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: live tests against a running API (and Gateway/Aomi); skipped unless their environment is set",
+]
+
 [tool.isort]
 line_length = 130
 profile = "black"

--- a/routers/executors.py
+++ b/routers/executors.py
@@ -52,12 +52,16 @@ async def create_executor(
     - **xemm_executor**: Cross-exchange market making
     - **order_executor**: Simple order execution
     - **lp_executor**: Liquidity provider position on CLMM DEXs (Meteora, Raydium, etc.)
+    - **onchain_executor**: One on-chain transaction bundle through the Aomi Pipeline (stage, simulate, commit)
 
     The `executor_config` must include:
     - `type`: One of the executor types above
     - `connector_name`: Exchange connector (e.g., "binance", "binance_perpetual")
     - `trading_pair`: Trading pair (e.g., "BTC-USDT")
     - Additional type-specific configuration (see /executors/types/{type}/config for details)
+
+    `onchain_executor` takes no connector: it needs `chain_id` and `mode` ("operation" with `operation`/`arguments`,
+    or "calls" with a list of EVM calls); `connector_name`/`trading_pair` are derived from the chain when omitted.
 
     Returns the created executor ID and initial status.
     """
@@ -293,6 +297,11 @@ async def get_available_executor_types():
                 "type": "lp_executor",
                 "description": "LP position management for CLMM pools (Meteora, Raydium) ",
                 "use_case": "Automated liquidity provision with position tracking"
+            },
+            {
+                "type": "onchain_executor",
+                "description": "One on-chain transaction bundle through the Aomi Pipeline: stage, fork-simulate, commit",
+                "use_case": "Kernel-signed EVM transactions (transfers, contract calls, catalog operations) without a connector"
             }
         ]
     }

--- a/routers/executors.py
+++ b/routers/executors.py
@@ -161,6 +161,21 @@ async def list_executors(
         raise HTTPException(status_code=500, detail=f"Error listing executors: {str(e)}")
 
 
+@router.get("/lending/positions")
+async def get_lending_positions(executor_service: ExecutorService = Depends(get_executor_service)):
+    """Attributed contributions and unresolved attempts, including completed executors.
+
+    Raw amounts are strings. These are not live balances or available withdrawals;
+    receipt-token balances must be reconciled separately. A storage or history error
+    returns 503, never a partial list or a zero balance.
+    """
+    try:
+        return {"positions": await executor_service.get_lending_positions()}
+    except Exception:
+        logger.exception("Lending position history is unavailable")
+        raise HTTPException(status_code=503, detail="Lending position history is unavailable")
+
+
 @router.get("/summary", response_model=ExecutorsSummaryResponse)
 async def get_executors_summary(
     executor_service: ExecutorService = Depends(get_executor_service)

--- a/routers/executors.py
+++ b/routers/executors.py
@@ -10,6 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from starlette import status
 
+from config import settings
 from deps import get_executor_service, get_market_data_service
 from models.executors import (
     CreateExecutorRequest,
@@ -25,6 +26,7 @@ from models.executors import (
     StopExecutorRequest,
     StopExecutorResponse,
 )
+from models.onchain_preparation import OnchainPreparationRequest
 from models.pagination import PaginatedResponse
 from services.executor_service import ExecutorService
 from services.market_data_service import MarketDataService
@@ -33,6 +35,22 @@ from utils.trading_pair import InvalidTradingPair, split_trading_pair
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Executors"], prefix="/executors")
+
+
+@router.post("/onchain/prepare")
+async def onchain_preparation(request: OnchainPreparationRequest):
+    """Read markets/positions or prepare unsigned instructions through the configured Aomi app."""
+    from services.onchain_executor import OnchainExecutor
+    from services.onchain_preparation import prepare_onchain
+
+    try:
+        async with OnchainExecutor._default_client() as client:
+            return await prepare_onchain(request, client, application_id=settings.aomi.preparation_application_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        # Credential-bearing upstream URLs and bodies must not reach API clients.
+        raise HTTPException(status_code=502, detail="Aomi market preparation is unavailable")
 
 
 @router.post("/", response_model=CreateExecutorResponse, status_code=status.HTTP_201_CREATED)

--- a/routers/executors.py
+++ b/routers/executors.py
@@ -42,12 +42,20 @@ async def onchain_preparation(request: OnchainPreparationRequest):
     """Read markets/positions or prepare unsigned instructions through the configured Aomi app."""
     from services.onchain_executor import OnchainExecutor
     from services.onchain_preparation import prepare_onchain
+    from aomi.pipeline.errors import PipelineError
 
     try:
         async with OnchainExecutor._default_client() as client:
             return await prepare_onchain(request, client, application_id=settings.aomi.preparation_application_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    except PipelineError as exc:
+        # Log only typed status/code, never upstream bodies, URLs, or credentials.
+        logger.warning("Aomi preparation failed: status=%s code=%s", exc.status,
+                       "operation_in_flight" if exc.code == "operation_in_flight" else "pipeline_error")
+        if exc.status == 409 and exc.code == "operation_in_flight":
+            raise HTTPException(status_code=409, detail="Aomi account is busy. Wait for its current operation to finish, then try again.")
+        raise HTTPException(status_code=502, detail="Aomi market preparation is unavailable")
     except Exception:
         # Credential-bearing upstream URLs and bodies must not reach API clients.
         raise HTTPException(status_code=502, detail="Aomi market preparation is unavailable")

--- a/routers/executors.py
+++ b/routers/executors.py
@@ -161,6 +161,19 @@ async def list_executors(
         raise HTTPException(status_code=500, detail=f"Error listing executors: {str(e)}")
 
 
+@router.get("/lending/policy")
+async def get_lending_policy():
+    """Read the operator-owned grant; creation revalidates it under the database lock."""
+    from config import settings
+    from services.lending_policy import LendingPolicy
+
+    try:
+        policy = LendingPolicy.load(settings.aomi.lending_policy_file)
+        return policy.report() if policy else {"enabled": False}
+    except Exception:
+        raise HTTPException(status_code=503, detail="Lending policy unavailable")
+
+
 @router.get("/lending/positions")
 async def get_lending_positions(executor_service: ExecutorService = Depends(get_executor_service)):
     """Attributed contributions and unresolved attempts, including completed executors.

--- a/services/bots_orchestrator.py
+++ b/services/bots_orchestrator.py
@@ -26,8 +26,8 @@ class BotsOrchestrator:
         self.broker_username = broker_username
         self.broker_password = broker_password
 
-        # Initialize Docker client
-        self.docker_client = docker.from_env()
+        # Standalone executors do not need Docker. Connect when bot discovery runs.
+        self.docker_client = None
 
         # Initialize MQTT manager
         self.mqtt_manager = MQTTManager(host=broker_host, port=broker_port, username=broker_username, password=broker_password)
@@ -64,6 +64,8 @@ class BotsOrchestrator:
         return await loop.run_in_executor(None, self._sync_get_active_containers)
 
     def _sync_get_active_containers(self):
+        if self.docker_client is None:
+            self.docker_client = docker.from_env()
         return [
             container.name
             for container in self.docker_client.containers.list()

--- a/services/executor_service.py
+++ b/services/executor_service.py
@@ -35,7 +35,9 @@ from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
 
 from database import AsyncDatabaseManager, ExecutorRepository, GatewayCLMMRepository, GatewaySwapRepository
 from models.executors import PositionHold
+from models.onchain_executor import OnchainExecutorConfig
 from services.gateway_client import get_native_gas_token
+from services.onchain_executor import OnchainExecutor
 from services.trading_service import AccountTradingInterface, TradingService
 from utils.executor_log_capture import ExecutorLogCapture, current_executor_id
 from utils.trading_pair import InvalidTradingPair, split_trading_pair
@@ -126,6 +128,7 @@ class ExecutorService:
         "xemm_executor": (XEMMExecutor, XEMMExecutorConfig),
         "order_executor": (OrderExecutor, OrderExecutorConfig),
         "lp_executor": (LPExecutor, LPExecutorConfig),
+        "onchain_executor": (OnchainExecutor, OnchainExecutorConfig),
     }
 
     def __init__(
@@ -674,10 +677,13 @@ class ExecutorService:
         )
         executor_type = executor_config["type"]
 
-        # Ensure connector and market are ready
-        connector_name = executor_config.get("connector_name")
-        trading_pair = executor_config.get("trading_pair")
-        await self._prepare_market(account, connector_name, trading_pair)
+        # Ensure connector and market are ready. A connectorless executor (USES_CONNECTORS = False)
+        # derives its connector_name/trading_pair for the record only; preparing a market for it
+        # would try to build a Gateway connector out of a chain name.
+        connector_name = executor_config.get("connector_name") or getattr(typed_config, "connector_name", None)
+        trading_pair = executor_config.get("trading_pair") or getattr(typed_config, "trading_pair", None)
+        if getattr(executor_class, "USES_CONNECTORS", True):
+            await self._prepare_market(account, connector_name, trading_pair)
 
         # Instantiate the executor, register it in memory and start it
         controller_id = controller_id or getattr(typed_config, "controller_id", "main") or "main"

--- a/services/executor_service.py
+++ b/services/executor_service.py
@@ -611,7 +611,8 @@ class ExecutorService:
         executor_class: Type[ExecutorBase],
         typed_config: ExecutorConfigBase,
         trading_interface: AccountTradingInterface,
-        metadata: Dict[str, Any]
+        metadata: Dict[str, Any],
+        start: bool = True,
     ) -> tuple[str, ExecutorBase]:
         """
         Instantiate the executor, register it in memory and start it.
@@ -646,9 +647,12 @@ class ExecutorService:
         self._executor_metadata[executor_id] = metadata
 
         # Set ContextVar so the asyncio Task created by start() inherits it
-        token = current_executor_id.set(executor_id)
-        executor.start()
-        current_executor_id.reset(token)
+        if start:
+            token = current_executor_id.set(executor_id)
+            try:
+                executor.start()
+            finally:
+                current_executor_id.reset(token)
 
         return executor_id, executor
 
@@ -696,10 +700,25 @@ class ExecutorService:
             "created_at": datetime.now(timezone.utc),
             "config": executor_config
         }
-        executor_id, executor = self._instantiate_and_register(executor_class, typed_config, trading_interface, metadata)
+        durable_start = executor_type == "onchain_executor"
+        executor_id, executor = self._instantiate_and_register(
+            executor_class, typed_config, trading_interface, metadata, start=not durable_start
+        )
 
-        # Persist to database
-        await self._persist_executor_created(executor_id, executor)
+        # On-chain submissions must have durable attribution before any network action.
+        try:
+            await self._persist_executor_created(executor_id, executor)
+        except BaseException:
+            if durable_start:
+                self._active_executors.pop(executor_id, None)
+                self._executor_metadata.pop(executor_id, None)
+            raise
+        if durable_start:
+            token = current_executor_id.set(executor_id)
+            try:
+                executor.start()
+            finally:
+                current_executor_id.reset(token)
 
         # Capture created_at before potential cleanup
         created_at = metadata["created_at"].isoformat()
@@ -793,6 +812,26 @@ class ExecutorService:
                 logger.error(f"Error fetching executors from database: {e}")
 
         return result
+
+    async def get_lending_positions(self) -> List[Dict[str, Any]]:
+        """Read the full durable ledger; database failures must never look empty."""
+        from services.lending_positions import LendingPosition
+
+        if self.db_manager is None:
+            raise RuntimeError("Persistent executor storage is unavailable")
+        async with self.db_manager.get_session_context() as session:
+            repo = ExecutorRepository(session)
+            records = await repo.get_executors(executor_type="onchain_executor", limit=None)
+            by_id = {record.executor_id: self._format_db_record(record) for record in records}
+        # Live state supersedes the persisted snapshot for the same executor.
+        for executor_id, executor in self._active_executors.items():
+            if self._executor_metadata.get(executor_id, {}).get("executor_type") == "onchain_executor":
+                by_id[executor_id] = self._format_executor_info(executor_id, executor)
+        positions = LendingPosition.from_executors(by_id.values())
+        if not positions:
+            return []
+        async with OnchainExecutor._default_client() as client:
+            return await LendingPosition.read_wallet_balances(positions, client)
 
     async def get_executor(self, executor_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -1047,7 +1086,13 @@ class ExecutorService:
             await self._aggregate_position_hold(executor_id, executor, metadata)
 
         # Persist final state to database
-        await self._persist_executor_completed(executor_id, executor)
+        try:
+            await self._persist_executor_completed(executor_id, executor)
+        except BaseException:
+            # Keep the confirmed/uncertain result visible and retry persistence on
+            # the next control tick. The durable initial record also survives restart.
+            self._active_executors[executor_id] = executor
+            raise
 
         # The rent refund is only known once the close confirms, which is here. A
         # successful close has already cleared position_address from custom_info, so this
@@ -1363,7 +1408,10 @@ class ExecutorService:
 
     async def _persist_executor_created(self, executor_id: str, executor: ExecutorBase):
         """Persist executor creation to database."""
+        durable = self._executor_metadata.get(executor_id, {}).get("executor_type") == "onchain_executor"
         if not self.db_manager:
+            if durable:
+                raise RuntimeError("On-chain execution requires persistent executor storage")
             return
 
         try:
@@ -1387,10 +1435,15 @@ class ExecutorService:
 
         except Exception as e:
             logger.error(f"Error persisting executor creation: {e}")
+            if durable:
+                raise
 
     async def _persist_executor_completed(self, executor_id: str, executor: ExecutorBase):
         """Persist executor completion to database."""
+        durable = self._executor_metadata.get(executor_id, {}).get("executor_type") == "onchain_executor"
         if not self.db_manager:
+            if durable:
+                raise RuntimeError("On-chain completion requires persistent executor storage")
             return
 
         try:
@@ -1443,6 +1496,8 @@ class ExecutorService:
                 final_state_json = json.dumps(custom_info, default=_json_default)
             except Exception as e:
                 logger.warning(f"Failed to serialize custom_info for {executor_id}: {e}")
+                if durable:
+                    raise
                 # Try a simpler serialization without complex objects
                 try:
                     simple_info = {k: v for k, v in custom_info.items()
@@ -1487,6 +1542,8 @@ class ExecutorService:
 
         except Exception as e:
             logger.error(f"Error persisting executor completion: {e}")
+            if durable:
+                raise
 
     # ========================================
     # Position Hold Tracking Methods

--- a/services/executor_service.py
+++ b/services/executor_service.py
@@ -32,7 +32,9 @@ from hummingbot.strategy_v2.executors.twap_executor.twap_executor import TWAPExe
 from hummingbot.strategy_v2.executors.xemm_executor.data_types import XEMMExecutorConfig
 from hummingbot.strategy_v2.executors.xemm_executor.xemm_executor import XEMMExecutor
 from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+from sqlalchemy import text
 
+from config import settings
 from database import AsyncDatabaseManager, ExecutorRepository, GatewayCLMMRepository, GatewaySwapRepository
 from models.executors import PositionHold
 from models.onchain_executor import OnchainExecutorConfig
@@ -1419,6 +1421,21 @@ class ExecutorService:
 
             async with self.db_manager.get_session_context() as session:
                 repo = ExecutorRepository(session)
+                if durable and executor.config.commit:
+                    from services.lending_policy import LendingPolicy
+
+                    # One transaction owns validation and insertion. Later admissions see
+                    # this durable pending reservation, including after a process restart.
+                    if settings.aomi.lending_policy_file or executor.config.require_lending_policy:
+                        # Refresh the read snapshot after a competing writer releases the lock.
+                        await session.execute(text("SET TRANSACTION ISOLATION LEVEL READ COMMITTED"))
+                        await session.execute(text("SELECT pg_advisory_xact_lock(713840512345)"))
+                        policy = LendingPolicy.load(settings.aomi.lending_policy_file)
+                        if policy is None:
+                            raise ValueError("Automatic lending requires an active operator policy")
+                        records = await repo.get_executors(executor_type="onchain_executor", limit=None)
+                        policy.admit(executor.config, metadata["account_name"], metadata["controller_id"],
+                                     [self._format_db_record(record) for record in records])
 
                 await repo.create_executor(
                     executor_id=executor_id,

--- a/services/gateway_service.py
+++ b/services/gateway_service.py
@@ -35,11 +35,15 @@ class GatewayService:
         self.SOURCE_PATH = os.getcwd()
         # Use BOTS_PATH if set (for Docker), otherwise use SOURCE_PATH (for local)
         self.BOTS_PATH = os.environ.get('BOTS_PATH', self.SOURCE_PATH)
-        try:
-            self.client = docker.from_env()
-        except DockerException as e:
-            logger.error(f"Failed to connect to Docker. Error: {e}")
-            raise
+        self._client = None
+
+    @property
+    def client(self):
+        # Defer Docker discovery until a Gateway operation is requested. Aomi
+        # and CEX executors can run while Docker/Gateway is unavailable.
+        if self._client is None:
+            self._client = docker.from_env()
+        return self._client
 
     def _gateway_base(self, host: bool = False) -> str:
         """Gateway-files base. host=False is the path the API process reads/writes

--- a/services/lending_policy.py
+++ b/services/lending_policy.py
@@ -1,0 +1,86 @@
+"""Operator-owned Base USDC allocation limits, enforced before durable admission."""
+import json
+import re
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from aomi.pipeline import LendingPlan
+
+from services.lending_positions import BASE_AAVE_USDC, LendingPosition
+
+
+class LendingPolicy:
+    def __init__(self, data: Dict[str, Any]):
+        allowed = {"wallet", "account_name", "controller_limits_raw", "max_total_supply_raw", "max_action_raw", "max_gas_quote"}
+        if not isinstance(data, dict) or set(data) != allowed:
+            raise ValueError("Lending policy must specify wallet, account, controller limits, total, action and gas limits")
+        self.wallet = data["wallet"]
+        if not isinstance(self.wallet, str) or not re.fullmatch(r"0x[0-9a-fA-F]{40}", self.wallet):
+            raise ValueError("Invalid policy wallet")
+        self.wallet = self.wallet.lower()
+        self.account = data["account_name"]
+        if not isinstance(self.account, str) or not self.account:
+            raise ValueError("Invalid policy account")
+        grants = data["controller_limits_raw"]
+        if not isinstance(grants, dict) or not grants or any(not isinstance(k, str) or not k for k in grants):
+            raise ValueError("Policy requires named controller grants")
+        self.controllers = {k: self.units(v) for k, v in grants.items()}
+        self.total = self.units(data["max_total_supply_raw"])
+        self.action = self.units(data["max_action_raw"])
+        self.gas = Decimal(str(data["max_gas_quote"]))
+        if not self.gas.is_finite() or self.gas <= 0:
+            raise ValueError("Policy gas limit must be positive and finite")
+
+    @staticmethod
+    def units(value: Any) -> int:
+        if not isinstance(value, str) or not re.fullmatch(r"[0-9]+", value) or not 0 < int(value) < 2 ** 256 - 1:
+            raise ValueError("Policy amounts must be positive bounded raw-unit strings")
+        return int(value)
+
+    @classmethod
+    def load(cls, path: str):
+        return cls(json.loads(Path(path).read_text())) if path else None
+
+    def report(self) -> Dict[str, Any]:
+        return {
+            "enabled": True, "chain_id": BASE_AAVE_USDC[0], "pool": BASE_AAVE_USDC[1], "asset": BASE_AAVE_USDC[2],
+            "wallet": self.wallet, "account_name": self.account, "decimals": 6,
+            "controller_limits_raw": {k: str(v) for k, v in self.controllers.items()},
+            "max_total_supply_raw": str(self.total), "max_action_raw": str(self.action), "max_gas_quote": str(self.gas),
+            "scope": "net_contributions_and_pending_supplies", "automatic_admission": "database_serialized",
+        }
+
+    def admit(self, config, account: str, controller: str, records: Iterable[Dict[str, Any]]):
+        if config.commit is False:
+            return
+        plan = config.lending
+        if config.mode != "lending" or not isinstance(plan, LendingPlan):
+            raise ValueError("Configured lending policy permits only exact lending plans")
+        if account != self.account or controller not in self.controllers:
+            raise ValueError("Controller or account has no lending grant")
+        if (plan.chain_id, plan.pool, plan.asset) != BASE_AAVE_USDC or plan.wallet != self.wallet:
+            raise ValueError("Lending plan is outside the approved wallet and market")
+        if plan.amount > self.action or config.max_gas_quote is None or config.max_gas_quote > self.gas:
+            raise ValueError("Lending action or gas limit exceeds policy")
+        records = list(records)
+        # Raw historical commits cannot be reconstructed as lending contributions.
+        if any((r.get("config") or {}).get("commit") is not False
+               and (r.get("config") or {}).get("mode") != "lending" for r in records):
+            raise ValueError("Non-lending history requires reconciliation before automatic allocation")
+        positions = LendingPosition.from_executors(records)
+        total = own = controller_reserved = pending_withdraw = 0
+        for row in positions:
+            if (row["chain_id"], row["pool"], row["asset"], row["wallet"]) != (*BASE_AAVE_USDC, self.wallet):
+                continue
+            reserved = int(row["net_contributed_raw"]) + int(row["pending_supply_raw"])
+            total += reserved
+            if row["account_name"] == account and row["controller_id"] == controller:
+                controller_reserved += reserved
+                own += int(row["net_contributed_raw"])
+                pending_withdraw += int(row["pending_withdraw_raw"])
+        if plan.action == "supply":
+            if total + plan.amount > self.total or controller_reserved + plan.amount > self.controllers[controller]:
+                raise ValueError("Lending allocation exceeds remaining total or controller grant")
+        elif plan.amount > max(0, own - pending_withdraw):
+            raise ValueError("Withdrawal exceeds this controller's unreserved contributions")

--- a/services/lending_positions.py
+++ b/services/lending_positions.py
@@ -1,0 +1,149 @@
+"""Persistent lending contributions reconstructed from executor history.
+
+This is an attribution ledger, not a token balance or a yield calculation. A
+completed supply remains here until an explicit withdrawal, and even a zero net
+contribution requires a live receipt-token read before declaring a position closed.
+"""
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List
+
+from aomi.pipeline import LendingPlan
+
+# https://github.com/bgd-labs/aave-address-book/blob/main/src/AaveV3Base.sol
+# A receipt-token balance is wallet-wide; it is never silently attributed to one controller.
+BASE_AAVE_USDC = (
+    8453, "0xa238dd80c259a72e81d7e4664a9801593f98d1c5", "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+)
+
+
+@dataclass
+class LendingPosition:
+    account_name: str
+    controller_id: str
+    chain_id: int
+    wallet: str
+    pool: str
+    asset: str
+    supplied: int = 0
+    withdrawn: int = 0
+    pending_supply: int = 0
+    pending_withdraw: int = 0
+    executor_ids: List[str] = field(default_factory=list)
+    unresolved_executor_ids: List[str] = field(default_factory=list)
+
+    def report(self) -> Dict[str, Any]:
+        return {
+            "account_name": self.account_name,
+            "controller_id": self.controller_id,
+            "chain_id": self.chain_id,
+            "wallet": self.wallet,
+            "pool": self.pool,
+            "asset": self.asset,
+            "supplied_raw": str(self.supplied),
+            "withdrawn_raw": str(self.withdrawn),
+            "net_contributed_raw": str(max(0, self.supplied - self.withdrawn)),
+            "pending_supply_raw": str(self.pending_supply),
+            "pending_withdraw_raw": str(self.pending_withdraw),
+            "executor_ids": sorted(self.executor_ids),
+            "unresolved_executor_ids": sorted(self.unresolved_executor_ids),
+            "requires_balance_reconciliation": True,
+        }
+
+    @staticmethod
+    async def read_wallet_balances(positions: List[Dict[str, Any]], client) -> List[Dict[str, Any]]:
+        balances = {}
+        for position in positions:
+            market = (position["chain_id"], position["pool"], position["asset"])
+            if market != BASE_AAVE_USDC:
+                position["balance_status"] = "unsupported_market"
+                continue
+            key = (*market, position["wallet"])
+            if key not in balances:
+                token = "0x4e65fe4dba92790696d040ac24aa414708f5c0ab"
+                result = await client.evm_token_holdings(8453, token, position["wallet"])
+                if (
+                    not isinstance(result, dict)
+                    or result.get("chain_id") != 8453
+                    or str(result.get("token", "")).lower() != token
+                    or str(result.get("holder", "")).lower() != position["wallet"]
+                    or result.get("decimals") != 6
+                    or not isinstance(result.get("balance_raw"), str)
+                    or not re.fullmatch(r"[0-9]+", result["balance_raw"])
+                ):
+                    raise ValueError("Receipt-token balance response does not match the requested market")
+                balances[key] = result["balance_raw"]
+            position.update({
+                "balance_status": "verified_wallet_balance",
+                "wallet_receipt_balance_raw": balances[key],
+                "receipt_token": "0x4e65fe4dba92790696d040ac24aa414708f5c0ab",
+                "decimals": 6,
+                "symbol": "USDC",
+                "balance_scope": "wallet",
+                # Do not distribute interest or untracked external deposits among controllers.
+                "requires_balance_reconciliation": bool(position["unresolved_executor_ids"])
+                or int(balances[key]) != 0,
+            })
+        return positions
+
+    @classmethod
+    def from_executors(cls, records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        positions = {}
+        seen_ids = set()
+        seen_receipts = {}
+        for record in records:
+            cfg = record.get("config") or {}
+            if cfg.get("mode") != "lending" or cfg.get("commit") is False:
+                continue
+            raw_plan = cfg.get("lending")
+            if not isinstance(raw_plan, dict):
+                raise ValueError("Lending history contains an invalid plan")
+            raw_plan = dict(raw_plan)
+            amount = raw_plan.get("amount")
+            if isinstance(amount, str) and re.fullmatch(r"[0-9]+", amount):
+                raw_plan["amount"] = int(amount)
+            plan = LendingPlan(**raw_plan)
+            executor_id = record.get("executor_id") or record.get("id")
+            if not isinstance(executor_id, str) or not executor_id or executor_id in seen_ids:
+                raise ValueError("Lending history contains missing or duplicate executor IDs")
+            seen_ids.add(executor_id)
+            info = record.get("custom_info") or {}
+            confirmed = info.get("committed") is True
+            # An explicitly unsent terminal attempt cannot hold capital. Older
+            # records without this evidence stay unresolved rather than becoming zero.
+            if (not confirmed and str(record.get("status")).upper() == "TERMINATED"
+                    and info.get("commit_attempted") is False):
+                continue
+            account = record.get("account_name")
+            controller = record.get("controller_id")
+            if not isinstance(account, str) or not account or not isinstance(controller, str) or not controller:
+                raise ValueError("Lending history is missing account attribution")
+            key = (account, controller, plan.chain_id, plan.wallet, plan.pool, plan.asset)
+            position = positions.setdefault(key, cls(*key))
+            if confirmed:
+                hashes = info.get("tx_hashes")
+                if not isinstance(hashes, list) or not hashes or any(
+                    not isinstance(h, str) or not re.fullmatch(r"0x[0-9a-fA-F]{64}", h) for h in hashes
+                ):
+                    raise ValueError("Confirmed lending history is missing transaction receipts")
+                identity = (key, plan.action, plan.amount, tuple(sorted(h.lower() for h in hashes)))
+                receipts = [(plan.chain_id, h.lower()) for h in hashes]
+                prior = [seen_receipts[r] for r in receipts if r in seen_receipts]
+                if prior:
+                    if len(prior) != len(receipts) or any(p != identity for p in prior):
+                        raise ValueError("Lending history contains conflicting receipt attribution")
+                    position.executor_ids.append(executor_id)
+                    continue  # idempotent commit replay, not another deposit
+                seen_receipts.update({r: identity for r in receipts})
+                if plan.action == "supply":
+                    position.supplied += plan.amount
+                else:
+                    position.withdrawn += plan.amount
+            else:
+                if plan.action == "supply":
+                    position.pending_supply += plan.amount
+                else:
+                    position.pending_withdraw += plan.amount
+                position.unresolved_executor_ids.append(executor_id)
+            position.executor_ids.append(executor_id)
+        return [positions[key].report() for key in sorted(positions)]

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -1,0 +1,412 @@
+"""OnchainExecutor: one Aomi Pipeline lifecycle as a hummingbot executor.
+
+The executor walks stage (or build) -> simulate -> risk check -> commit -> confirm, one phase per
+control tick, against ``/v1/pipeline`` through the ``aomi`` client. It holds no connector: the
+fork simulation is what proves balances and the kernel signs on commit, so ``ExecutorBase`` is
+constructed with ``connectors=[]`` and the balance check is a no-op.
+
+Two things it is careful about:
+
+* A commit is sent at most once. ``_commit_sent`` flips before the request leaves, and a retry
+  after a transport error replays the same idempotency key (the Build digest), so a lost response
+  cannot turn into a second on-chain transaction. ``early_stop`` after that point is a no-op.
+* ``custom_info`` never carries ``transaction_hash`` or ``position_address``: the ExecutorService
+  reads the first as a Gateway swap to record and the second as an orphaned LP position.
+"""
+import dataclasses
+import inspect
+import logging
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+from aomi.pipeline.client import PipelineClient
+from aomi.pipeline.errors import PipelineError
+from aomi.pipeline.models import Build, CommitOutcome
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.strategy_v2.executors.executor_base import ExecutorBase
+from hummingbot.strategy_v2.models.executors import CloseType
+from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
+
+from config import settings
+from models.onchain_executor import OnchainExecutorConfig, native_symbol
+from utils.trading_pair import split_trading_pair
+
+LOGGER_NAME = "hummingbot.strategy_v2.executors.onchain_executor"
+
+
+class OnchainExecutorInfo(ExecutorInfo):
+    """ExecutorInfo whose config is an OnchainExecutorConfig.
+
+    Core's ``ExecutorInfo.config`` is a discriminated union of the eight core configs, so a config
+    typed ``onchain_executor`` cannot pass through it.
+    """
+
+    config: OnchainExecutorConfig
+
+
+class Phase(str, Enum):
+    STAGING = "staging"
+    SIMULATING = "simulating"
+    RISK_CHECK = "risk_check"
+    COMMITTING = "committing"
+    CONFIRMING = "confirming"
+    DONE = "done"
+
+
+class OnchainExecutor(ExecutorBase):
+    """Stage, simulate and commit one on-chain bundle through the Aomi Pipeline."""
+
+    # The ExecutorService skips connector/market preparation for executors that say so.
+    USES_CONNECTORS = False
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        # RunnableBase logs under hummingbot.strategy_v2.runnable_base, which the API's per-executor
+        # log capture (attached to hummingbot.strategy_v2.executors) never sees.
+        if cls._logger is None:
+            cls._logger = logging.getLogger(LOGGER_NAME)
+        return cls._logger
+
+    def __init__(
+        self,
+        strategy,
+        config: OnchainExecutorConfig,
+        update_interval: float = 1.0,
+        max_retries: int = 10,
+        client_factory: Optional[Callable[[], PipelineClient]] = None,
+    ):
+        super().__init__(
+            strategy=strategy, connectors=[], config=config, update_interval=update_interval, max_retries=max_retries
+        )
+        self.config: OnchainExecutorConfig = config
+        self._client_factory = client_factory
+        self._client: Optional[PipelineClient] = None
+        self._phase = Phase.STAGING
+        self._build: Optional[Build] = None
+        self._outcome: Optional[CommitOutcome] = None
+        self._error: Optional[Dict[str, Any]] = None
+        self._started_at: Optional[float] = None
+        self._commit_sent = False
+        self._stop_requested = False
+
+    # ------------------------------------------------------------------ lifecycle
+
+    @staticmethod
+    def _default_client() -> PipelineClient:
+        aomi = settings.aomi
+        return PipelineClient(aomi.url, aomi.token_provider(), timeout=aomi.timeout)
+
+    async def validate_sufficient_balance(self):
+        # The fork simulation proves the wallet can pay; a failing one ends the executor at RISK_CHECK.
+        return
+
+    async def on_start(self):
+        try:
+            if self._client is None:
+                if self._client_factory is None and not settings.aomi.configured:
+                    raise RuntimeError("Aomi is not configured: set AOMI_TOKEN or AOMI_TOKEN_FILE")
+                self._client = (self._client_factory or self._default_client)()
+            self._started_at = self._strategy.current_timestamp
+            await self.validate_sufficient_balance()
+            self.logger().info(
+                f"onchain_executor {self.config.id} starting: chain_id={self.config.chain_id} mode={self.config.mode} "
+                f"app={self.config.app} operation={self.config.operation}"
+            )
+        except Exception as exc:
+            self._fail("startup", exc)
+
+    def on_stop(self):
+        client, self._client = self._client, None
+        if client is not None:
+            safe_ensure_future(client.close())
+
+    def early_stop(self, keep_position: bool = False):
+        if self._commit_sent:
+            self.logger().warning(
+                f"onchain_executor {self.config.id}: commit already sent (digest {self._digest}); an on-chain commit "
+                "cannot be cancelled, letting it finish"
+            )
+            return
+        self._stop_requested = True
+        self.close_type = CloseType.EARLY_STOP
+        self.logger().info(f"onchain_executor {self.config.id} stopped early during {self._phase.value}")
+        self.stop()
+
+    async def control_task(self):
+        if self.is_closed or self._phase == Phase.DONE:
+            return
+        if not self._commit_sent and self._timed_out():
+            self._fail("timeout", message=f"no commit within {self.config.timeout_sec}s (phase {self._phase.value})")
+            return
+        phase = self._phase
+        try:
+            if phase == Phase.STAGING:
+                await self._stage()
+            elif phase == Phase.SIMULATING:
+                await self._simulate()
+            elif phase == Phase.RISK_CHECK:
+                self._risk_check()
+            elif phase == Phase.COMMITTING:
+                await self._commit()
+            elif phase == Phase.CONFIRMING:
+                self._confirm()
+        except PipelineError as err:
+            if err.retryable:
+                self._current_retries += 1
+                self.logger().warning(
+                    f"onchain_executor {self.config.id}: {phase.value} failed with a retryable error "
+                    f"({err.status} {err.code}: {err.message}); retry {self._current_retries}/{self._max_retries}"
+                )
+            else:
+                self._fail(f"{phase.value}_rejected", err)
+        except Exception as exc:
+            self._fail("unexpected", exc)
+
+    # ------------------------------------------------------------------ phases
+
+    async def _stage(self):
+        cfg = self.config
+        if cfg.mode == "calls":
+            self._build = await self._client.stage_evm(cfg.calls, app=cfg.app, skills=cfg.skills)
+        else:
+            self._build = await self._client.build(
+                cfg.chain, app=cfg.app, skills=cfg.skills, operation=cfg.operation_path, arguments=cfg.arguments or {}
+            )
+        self.logger().info(
+            f"onchain_executor {cfg.id}: staged {len(self._build.actions)} action(s), digest {self._build.digest}, "
+            f"status {self._build.status}"
+        )
+        self._phase = Phase.RISK_CHECK if self._build.is_simulated else Phase.SIMULATING
+
+    async def _simulate(self):
+        self._build = await self._client.simulate(self._build)
+        self._phase = Phase.RISK_CHECK
+
+    def _risk_check(self):
+        build = self._build
+        simulation = build.simulation if build is not None else None
+        if simulation is None or not simulation.passed:
+            status = simulation.status if simulation is not None else "missing"
+            warnings = simulation.warnings if simulation is not None else []
+            self._fail(
+                "simulation_failed",
+                message=f"simulation {status}" + (f": {'; '.join(warnings)}" if warnings else ""),
+                evidence=simulation.raw if simulation is not None else None,
+            )
+            return
+        for warning in simulation.warnings:
+            self.logger().warning(f"onchain_executor {self.config.id}: simulation warning: {warning}")
+        if self.config.max_gas_quote is not None:
+            fees = self.get_cum_fees_quote()
+            if self._fees_are_priced() and fees > self.config.max_gas_quote:
+                self._fail(
+                    "gas_over_budget",
+                    message=f"simulated gas {fees} quote exceeds max_gas_quote {self.config.max_gas_quote}",
+                )
+                return
+            if not self._fees_are_priced():
+                self.logger().warning(
+                    f"onchain_executor {self.config.id}: max_gas_quote set but no quote rate for "
+                    f"{native_symbol(self.config.chain_id)}; gas budget not enforced"
+                )
+        if not self.config.commit:
+            self.logger().info(f"onchain_executor {self.config.id}: dry run, simulation passed, not committing")
+            self._finish(CloseType.COMPLETED)
+            return
+        self._phase = Phase.COMMITTING
+
+    async def _commit(self):
+        # Flip before the request leaves so a lost response cannot lead to a second commit; the
+        # idempotency key is the Build digest, so a retry replays the ledger entry instead.
+        self._commit_sent = True
+        self._outcome = await self._client.commit(self._build)
+        self._phase = Phase.CONFIRMING
+
+    def _confirm(self):
+        outcome = self._outcome
+        if outcome is not None and outcome.confirmed:
+            self.logger().info(f"onchain_executor {self.config.id}: confirmed {', '.join(outcome.tx_hashes)}")
+            self._finish(CloseType.COMPLETED)
+            return
+        kind = outcome.kind if outcome is not None else "unknown"
+        self._error = {
+            "reason": "awaiting_wallet",
+            "phase": Phase.CONFIRMING.value,
+            "outcome_kind": kind,
+            "message": f"commit returned {kind}; the bundle needs a wallet signature this executor cannot give",
+        }
+        self.logger().error(f"onchain_executor {self.config.id}: {self._error['message']}")
+        self._finish(CloseType.FAILED)
+
+    def _finish(self, close_type: CloseType):
+        self.close_type = close_type
+        self._phase = Phase.DONE
+        self.stop()
+
+    def _fail(
+        self,
+        reason: str,
+        exc: Optional[BaseException] = None,
+        *,
+        message: Optional[str] = None,
+        evidence: Any = None,
+    ):
+        error: Dict[str, Any] = {"reason": reason, "phase": self._phase.value}
+        if isinstance(exc, PipelineError):
+            error.update({
+                "status": exc.status,
+                "code": exc.code,
+                "backend_code": exc.backend_code,
+                "message": exc.message,
+                "request_id": exc.request_id,
+            })
+        elif exc is not None:
+            error["message"] = f"{type(exc).__name__}: {exc}"
+        if message:
+            error["message"] = message
+        if evidence is not None:
+            error["evidence"] = evidence
+        self._error = error
+        self.logger().error(
+            f"onchain_executor {self.config.id} failed at {self._phase.value}: {reason}: {error.get('message', '')}",
+            exc_info=exc if exc is not None and not isinstance(exc, PipelineError) else None,
+        )
+        self._finish(CloseType.FAILED)
+
+    def _timed_out(self) -> bool:
+        if self._started_at is None:
+            return False
+        return (self._strategy.current_timestamp - self._started_at) > self.config.timeout_sec
+
+    # ------------------------------------------------------------------ metrics
+
+    def get_net_pnl_quote(self) -> Decimal:
+        return Decimal("0")
+
+    def get_net_pnl_pct(self) -> Decimal:
+        return Decimal("0")
+
+    @property
+    def filled_amount_quote(self) -> Decimal:
+        return Decimal("0")
+
+    def get_cum_fees_quote(self) -> Decimal:
+        cost = self._gas_native_cost()
+        rate = self._quote_rate()
+        if cost is None or rate is None:
+            return Decimal("0")
+        return cost * rate
+
+    def _fees_are_priced(self) -> bool:
+        return self._gas_native_cost() is not None and self._quote_rate() is not None
+
+    def _gas_native_cost(self) -> Optional[Decimal]:
+        simulation = self._build.simulation if self._build is not None else None
+        gas = simulation.gas if simulation is not None else None
+        if gas is None or gas.native_cost is None:
+            return None
+        try:
+            return Decimal(str(gas.native_cost))
+        except (InvalidOperation, ValueError):
+            return None
+
+    def _quote_rate(self) -> Optional[Decimal]:
+        """Price of the native gas token in the pair's quote asset, when the API can supply one."""
+        market_data = getattr(self._strategy, "_market_data_service", None)
+        get_rate = getattr(market_data, "get_rate", None)
+        if not callable(get_rate):
+            return None
+        try:
+            _base, quote_asset = split_trading_pair(self.config.trading_pair)
+            rate = get_rate(native_symbol(self.config.chain_id), quote_asset)
+        except Exception:  # a malformed pair (InvalidTradingPair) or a rate source that throws: unpriced
+            return None
+        if inspect.isawaitable(rate):
+            rate.close()
+            return None
+        if rate is None:
+            return None
+        try:
+            rate = Decimal(str(rate))
+        except (InvalidOperation, ValueError):
+            return None
+        return rate if rate > 0 else None
+
+    # ------------------------------------------------------------------ reporting
+
+    @property
+    def _digest(self) -> Optional[str]:
+        return self._build.digest if self._build is not None else None
+
+    @property
+    def executor_info(self) -> OnchainExecutorInfo:
+        def _safe_decimal(value) -> Decimal:
+            d = Decimal(str(value))
+            return d if d.is_finite() else Decimal("0")
+
+        return OnchainExecutorInfo(
+            id=self.config.id,
+            timestamp=self.config.timestamp,
+            type=self.config.type,
+            status=self.status,
+            close_type=self.close_type,
+            close_timestamp=self.close_timestamp,
+            config=self.config,
+            net_pnl_pct=_safe_decimal(self.net_pnl_pct),
+            net_pnl_quote=_safe_decimal(self.net_pnl_quote),
+            cum_fees_quote=_safe_decimal(self.cum_fees_quote),
+            filled_amount_quote=_safe_decimal(self.filled_amount_quote),
+            is_active=self.is_active,
+            is_trading=self.is_trading,
+            custom_info=self.get_custom_info(),
+            controller_id=self.config.controller_id,
+        )
+
+    def get_custom_info(self) -> Dict[str, Any]:
+        cfg = self.config
+        build = self._build
+        outcome = self._outcome
+        simulation = build.simulation if build is not None else None
+        gas = simulation.gas if simulation is not None else None
+        actions: List[Dict[str, Any]] = [
+            {
+                "chain_id": action.get("chain_id", action.get("chainId")),
+                "to": action.get("to"),
+                "value": action.get("value"),
+                "label": action.get("label"),
+                "kind": action.get("kind"),
+                "protocol": action.get("protocol"),
+                "pending_tx_id": action.get("pending_tx_id", action.get("pendingTxId")),
+            }
+            for action in (build.actions if build is not None else [])
+        ]
+        return {
+            "phase": self._phase.value,
+            "chain": cfg.chain,
+            "chain_id": cfg.chain_id,
+            "mode": cfg.mode,
+            "app": cfg.app,
+            "operation": cfg.operation,
+            "wallet_address": build.from_address if build is not None else None,
+            "digest": self._digest,
+            "action_count": len(actions),
+            "actions": actions,
+            "simulation_passed": simulation.passed if simulation is not None else None,
+            "simulation_warnings": list(simulation.warnings) if simulation is not None else [],
+            "balance_changes": [dataclasses.asdict(change) for change in simulation.balance_changes]
+            if simulation is not None else [],
+            "gas_units": gas.units if gas is not None else None,
+            "gas_price_wei": gas.price_wei if gas is not None else None,
+            "gas_native_cost": gas.native_cost if gas is not None else None,
+            "fees_quote_source": "priced" if self._fees_are_priced() else "unpriced",
+            "committed": bool(outcome is not None and outcome.confirmed),
+            "outcome_kind": outcome.kind if outcome is not None else None,
+            "tx_hashes": list(outcome.tx_hashes) if outcome is not None else [],
+            "tx_ids": list(outcome.tx_ids) if outcome is not None else [],
+            "commit_requests": list(outcome.requests) if outcome is not None else [],
+            "keep_position": cfg.keep_position,
+            "error": self._error,
+            "reason": self._error.get("reason") if self._error else None,
+        }

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -370,18 +370,7 @@ class OnchainExecutor(ExecutorBase):
         outcome = self._outcome
         simulation = build.simulation if build is not None else None
         gas = simulation.gas if simulation is not None else None
-        actions: List[Dict[str, Any]] = [
-            {
-                "chain_id": action.get("chain_id", action.get("chainId")),
-                "to": action.get("to"),
-                "value": action.get("value"),
-                "label": action.get("label"),
-                "kind": action.get("kind"),
-                "protocol": action.get("protocol"),
-                "pending_tx_id": action.get("pending_tx_id", action.get("pendingTxId")),
-            }
-            for action in (build.actions if build is not None else [])
-        ]
+        actions: List[Dict[str, Any]] = build.action_summaries if build is not None else []
         return {
             "phase": self._phase.value,
             "chain": cfg.chain,
@@ -390,6 +379,7 @@ class OnchainExecutor(ExecutorBase):
             "app": cfg.app,
             "operation": cfg.operation,
             "wallet_address": build.from_address if build is not None else None,
+            "cluster": cfg.cluster if cfg.chain == "svm" else None,
             "digest": self._digest,
             "action_count": len(actions),
             "actions": actions,

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -30,7 +30,6 @@ from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
 
 from config import settings
 from models.onchain_executor import OnchainExecutorConfig, native_symbol
-from utils.trading_pair import split_trading_pair
 
 LOGGER_NAME = "hummingbot.strategy_v2.executors.onchain_executor"
 
@@ -207,10 +206,8 @@ class OnchainExecutor(ExecutorBase):
                 )
                 return
             if not self._fees_are_priced():
-                self.logger().warning(
-                    f"onchain_executor {self.config.id}: max_gas_quote set but no quote rate for "
-                    f"{native_symbol(self.config.chain_id)}; gas budget not enforced"
-                )
+                self._fail("gas_unpriced", message="Cannot verify max_gas_quote in USDT: gas estimate or price unavailable")
+                return
         if not self.config.commit:
             self.logger().info(f"onchain_executor {self.config.id}: dry run, simulation passed, not committing")
             self._finish(CloseType.COMPLETED)
@@ -308,19 +305,20 @@ class OnchainExecutor(ExecutorBase):
         if gas is None or gas.native_cost is None:
             return None
         try:
-            return Decimal(str(gas.native_cost))
+            cost = Decimal(str(gas.native_cost))
+            return cost if cost.is_finite() and cost >= 0 else None
         except (InvalidOperation, ValueError):
             return None
 
     def _quote_rate(self) -> Optional[Decimal]:
-        """Price of the native gas token in the pair's quote asset, when the API can supply one."""
+        """Price of the native gas token in USDT, shared with Condor risk accounting."""
         market_data = getattr(self._strategy, "_market_data_service", None)
         get_rate = getattr(market_data, "get_rate", None)
         if not callable(get_rate):
             return None
         try:
-            _base, quote_asset = split_trading_pair(self.config.trading_pair)
-            rate = get_rate(native_symbol(self.config.chain_id), quote_asset)
+            symbol = "SOL" if self.config.chain == "svm" else native_symbol(self.config.chain_id)
+            rate = get_rate(symbol, "USDT")
         except Exception:  # a malformed pair (InvalidTradingPair) or a rate source that throws: unpriced
             return None
         if inspect.isawaitable(rate):
@@ -332,7 +330,7 @@ class OnchainExecutor(ExecutorBase):
             rate = Decimal(str(rate))
         except (InvalidOperation, ValueError):
             return None
-        return rate if rate > 0 else None
+        return rate if rate.is_finite() and rate > 0 else None
 
     # ------------------------------------------------------------------ reporting
 
@@ -390,6 +388,7 @@ class OnchainExecutor(ExecutorBase):
             "gas_units": gas.units if gas is not None else None,
             "gas_price_wei": gas.price_wei if gas is not None else None,
             "gas_native_cost": gas.native_cost if gas is not None else None,
+            "quote_asset": "USDT",
             "fees_quote_source": "priced" if self._fees_are_priced() else "unpriced",
             "committed": bool(outcome is not None and outcome.confirmed),
             "outcome_kind": outcome.kind if outcome is not None else None,

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -167,7 +167,9 @@ class OnchainExecutor(ExecutorBase):
 
     async def _stage(self):
         cfg = self.config
-        if cfg.mode == "calls":
+        if cfg.mode == "lending":
+            self._build = await self._client.stage_evm(cfg.lending.calls(), app=cfg.app, skills=cfg.skills)
+        elif cfg.mode == "calls":
             self._build = await self._client.stage_evm(cfg.calls, app=cfg.app, skills=cfg.skills)
         else:
             self._build = await self._client.build(
@@ -195,6 +197,12 @@ class OnchainExecutor(ExecutorBase):
                 evidence=simulation.raw if simulation is not None else None,
             )
             return
+        if self.config.lending is not None:
+            try:
+                self.config.lending.verify(build)
+            except ValueError as exc:
+                self._fail("lending_plan_changed", exc)
+                return
         for warning in simulation.warnings:
             self.logger().warning(f"onchain_executor {self.config.id}: simulation warning: {warning}")
         if self.config.max_gas_quote is not None:
@@ -206,7 +214,9 @@ class OnchainExecutor(ExecutorBase):
                 )
                 return
             if not self._fees_are_priced():
-                self._fail("gas_unpriced", message="Cannot verify max_gas_quote in USDT: gas estimate or price unavailable")
+                self._fail(
+                    "gas_unpriced", message="Cannot verify max_gas_quote in USDT: gas estimate or price unavailable"
+                )
                 return
         if not self.config.commit:
             self.logger().info(f"onchain_executor {self.config.id}: dry run, simulation passed, not committing")
@@ -379,6 +389,9 @@ class OnchainExecutor(ExecutorBase):
             "wallet_address": build.from_address if build is not None else None,
             "cluster": cfg.cluster if cfg.chain == "svm" else None,
             "digest": self._digest,
+            "build_expires_at": build.expires_at if build is not None else None,
+            "approvals": [dataclasses.asdict(change) for change in simulation.approvals]
+            if simulation is not None else [],
             "action_count": len(actions),
             "actions": actions,
             "simulation_passed": simulation.passed if simulation is not None else None,

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -404,6 +404,7 @@ class OnchainExecutor(ExecutorBase):
             "quote_asset": "USDT",
             "fees_quote_source": "priced" if self._fees_are_priced() else "unpriced",
             "committed": bool(outcome is not None and outcome.confirmed),
+            "commit_attempted": self._commit_sent,
             "outcome_kind": outcome.kind if outcome is not None else None,
             "tx_hashes": list(outcome.tx_hashes) if outcome is not None else [],
             "tx_ids": list(outcome.tx_ids) if outcome is not None else [],

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -13,6 +13,7 @@ Two things it is careful about:
 * ``custom_info`` never carries ``transaction_hash`` or ``position_address``: the ExecutorService
   reads the first as a Gateway swap to record and the second as an orphaned LP position.
 """
+
 import dataclasses
 import inspect
 import logging
@@ -206,7 +207,7 @@ class OnchainExecutor(ExecutorBase):
         for warning in simulation.warnings:
             self.logger().warning(f"onchain_executor {self.config.id}: simulation warning: {warning}")
         if self.config.max_gas_quote is not None:
-            fees = self.get_cum_fees_quote()
+            fees = self._estimated_gas_quote()
             if self._fees_are_priced() and fees > self.config.max_gas_quote:
                 self._fail(
                     "gas_over_budget",
@@ -214,9 +215,7 @@ class OnchainExecutor(ExecutorBase):
                 )
                 return
             if not self._fees_are_priced():
-                self._fail(
-                    "gas_unpriced", message="Cannot verify max_gas_quote in USDT: gas estimate or price unavailable"
-                )
+                self._fail("gas_unpriced", message="Cannot verify max_gas_quote in USDT: gas estimate or price unavailable")
                 return
         if not self.config.commit:
             self.logger().info(f"onchain_executor {self.config.id}: dry run, simulation passed, not committing")
@@ -262,13 +261,15 @@ class OnchainExecutor(ExecutorBase):
     ):
         error: Dict[str, Any] = {"reason": reason, "phase": self._phase.value}
         if isinstance(exc, PipelineError):
-            error.update({
-                "status": exc.status,
-                "code": exc.code,
-                "backend_code": exc.backend_code,
-                "message": exc.message,
-                "request_id": exc.request_id,
-            })
+            error.update(
+                {
+                    "status": exc.status,
+                    "code": exc.code,
+                    "backend_code": exc.backend_code,
+                    "message": exc.message,
+                    "request_id": exc.request_id,
+                }
+            )
         elif exc is not None:
             error["message"] = f"{type(exc).__name__}: {exc}"
         if message:
@@ -300,6 +301,11 @@ class OnchainExecutor(ExecutorBase):
         return Decimal("0")
 
     def get_cum_fees_quote(self) -> Decimal:
+        # Pipeline exposes a simulation estimate, not receipt-derived fees.
+        # Never book hypothetical gas as incurred trading fees.
+        return Decimal("0")
+
+    def _estimated_gas_quote(self) -> Decimal:
         cost = self._gas_native_cost()
         rate = self._quote_rate()
         if cost is None or rate is None:
@@ -390,19 +396,20 @@ class OnchainExecutor(ExecutorBase):
             "cluster": cfg.cluster if cfg.chain == "svm" else None,
             "digest": self._digest,
             "build_expires_at": build.expires_at if build is not None else None,
-            "approvals": [dataclasses.asdict(change) for change in simulation.approvals]
-            if simulation is not None else [],
+            "approvals": [dataclasses.asdict(change) for change in simulation.approvals] if simulation is not None else [],
             "action_count": len(actions),
             "actions": actions,
             "simulation_passed": simulation.passed if simulation is not None else None,
             "simulation_warnings": list(simulation.warnings) if simulation is not None else [],
-            "balance_changes": [dataclasses.asdict(change) for change in simulation.balance_changes]
-            if simulation is not None else [],
+            "balance_changes": (
+                [dataclasses.asdict(change) for change in simulation.balance_changes] if simulation is not None else []
+            ),
             "gas_units": gas.units if gas is not None else None,
             "gas_price_wei": gas.price_wei if gas is not None else None,
             "gas_native_cost": gas.native_cost if gas is not None else None,
             "quote_asset": "USDT",
-            "fees_quote_source": "priced" if self._fees_are_priced() else "unpriced",
+            "fees_quote_source": "unavailable",
+            "estimated_gas_quote": str(self._estimated_gas_quote()) if self._fees_are_priced() else None,
             "committed": bool(outcome is not None and outcome.confirmed),
             "commit_attempted": self._commit_sent,
             "outcome_kind": outcome.kind if outcome is not None else None,

--- a/services/onchain_executor.py
+++ b/services/onchain_executor.py
@@ -15,7 +15,9 @@ Two things it is careful about:
 """
 
 import dataclasses
+import hashlib
 import inspect
+import json
 import logging
 from decimal import Decimal, InvalidOperation
 from enum import Enum
@@ -172,6 +174,8 @@ class OnchainExecutor(ExecutorBase):
             self._build = await self._client.stage_evm(cfg.lending.calls(), app=cfg.app, skills=cfg.skills)
         elif cfg.mode == "calls":
             self._build = await self._client.stage_evm(cfg.calls, app=cfg.app, skills=cfg.skills)
+        elif cfg.mode == "instructions":
+            self._build = await self._client.stage_svm(instructions=cfg.instructions, app=cfg.app, skills=cfg.skills)
         else:
             self._build = await self._client.build(
                 cfg.chain, app=cfg.app, skills=cfg.skills, operation=cfg.operation_path, arguments=cfg.arguments or {}
@@ -204,8 +208,30 @@ class OnchainExecutor(ExecutorBase):
             except ValueError as exc:
                 self._fail("lending_plan_changed", exc)
                 return
+        if self.config.reviewed_svm_plan_hash is not None:
+            if self._svm_plan_hash() != self.config.reviewed_svm_plan_hash:
+                self._fail("reviewed_plan_changed", message="Solana execution plan differs from the reviewed preview")
+                return
+        if self.config.svm_spending_policy is not None:
+            try:
+                self.config.svm_spending_policy.verify(build, self.config.cluster)
+            except ValueError as exc:
+                self._fail("spending_policy_refused", exc)
+                return
         for warning in simulation.warnings:
             self.logger().warning(f"onchain_executor {self.config.id}: simulation warning: {warning}")
+        if self.config.max_svm_network_fee_lamports is not None:
+            fee = self._svm_network_fee_lamports()
+            if fee is None:
+                self._fail("network_fee_unavailable", message="Complete Solana network fee evidence is unavailable")
+                return
+            if fee > self.config.max_svm_network_fee_lamports:
+                self._fail(
+                    "network_fee_over_budget",
+                    message=f"Simulated network fee {fee} lamports exceeds the "
+                            f"{self.config.max_svm_network_fee_lamports}-lamport limit",
+                )
+                return
         if self.config.max_gas_quote is not None:
             fees = self._estimated_gas_quote()
             if self._fees_are_priced() and fees > self.config.max_gas_quote:
@@ -315,6 +341,70 @@ class OnchainExecutor(ExecutorBase):
     def _fees_are_priced(self) -> bool:
         return self._gas_native_cost() is not None and self._quote_rate() is not None
 
+    def _svm_network_fee_lamports(self) -> Optional[int]:
+        """Return a complete fee estimate, never a partial sum from missing simulation steps."""
+        build = self._build
+        simulation = build.simulation if build is not None else None
+        if build is None or build.chain != "svm" or simulation is None or not simulation.passed:
+            return None
+        guards = [g for g in simulation.guards if isinstance(g, dict) and g.get("name") == "svm_network_fees"]
+        if len(guards) != 1 or guards[0].get("status") != "passed" or not simulation.fees:
+            return None
+        wallet = build.from_address
+        if not wallet or not build.actions:
+            return None
+        for action in build.actions:
+            if not isinstance(action, dict):
+                return None
+            inner = action.get("instruction") or action.get("transaction")
+            if not isinstance(inner, dict) or inner.get("cluster") != self.config.cluster:
+                return None
+            if (inner.get("payer") or inner.get("fee_payer") or inner.get("feePayer")) != wallet:
+                return None
+        total = 0
+        for fee in simulation.fees:
+            if not isinstance(fee, dict) or (
+                fee.get("kind") != "network" or fee.get("asset") != "native"
+                or type(fee.get("decimals")) is not int or fee["decimals"] != 9
+                or fee.get("cluster") != self.config.cluster or fee.get("account") != wallet
+            ):
+                return None
+            amount = fee.get("amount")
+            if not isinstance(amount, str) or not amount.isascii() or not amount.isdecimal() or len(amount) > 20:
+                return None
+            value = int(amount)
+            if value > 2**64 - 1:
+                return None
+            total += value
+        return total
+
+    def _svm_plan_hash(self) -> Optional[str]:
+        """Seal an instruction plan across restaging, excluding only queue metadata and labels.
+
+        Unlike the Build digest this is stable when pending IDs and expiry change.
+        Include unknown instruction fields conservatively, including fee and assembly
+        metadata; a backend extension must never silently broaden reviewed authority.
+        """
+        build = self._build
+        if build is None or build.chain != "svm" or not build.actions:
+            return None
+        plan = []
+        for action in build.actions:
+            if not isinstance(action, dict):
+                return None
+            inner = action.get("instruction")
+            if action.get("lane") != "instruction" or not isinstance(inner, dict):
+                return None
+            if any(not isinstance(inner.get(key), str) or not inner[key] for key in ("payer", "cluster", "program_id")):
+                return None
+            if not isinstance(inner.get("data_base64"), str) or not isinstance(inner.get("accounts"), list):
+                return None
+            plan.append({key: value for key, value in inner.items() if key not in {
+                "pending_ix_id", "last_batch_status", "current_lifecycle", "description",
+            }})
+        encoded = json.dumps({"version": 1, "instructions": plan}, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        return hashlib.sha256(encoded.encode()).hexdigest()
+
     def _gas_native_cost(self) -> Optional[Decimal]:
         simulation = self._build.simulation if self._build is not None else None
         gas = simulation.gas if simulation is not None else None
@@ -385,6 +475,8 @@ class OnchainExecutor(ExecutorBase):
         simulation = build.simulation if build is not None else None
         gas = simulation.gas if simulation is not None else None
         actions: List[Dict[str, Any]] = build.action_summaries if build is not None else []
+        clusters = {action.get("cluster") for action in actions}
+        svm_fee = self._svm_network_fee_lamports()
         return {
             "phase": self._phase.value,
             "chain": cfg.chain,
@@ -393,14 +485,25 @@ class OnchainExecutor(ExecutorBase):
             "app": cfg.app,
             "operation": cfg.operation,
             "wallet_address": build.from_address if build is not None else None,
-            "cluster": cfg.cluster if cfg.chain == "svm" else None,
+            "cluster": next(iter(clusters)) if cfg.chain == "svm" and len(clusters) == 1 else None,
+            "requested_cluster": cfg.cluster if cfg.chain == "svm" else None,
             "digest": self._digest,
+            "svm_plan_hash": self._svm_plan_hash(),
+            "svm_spending_policy": cfg.svm_spending_policy.model_dump() if cfg.svm_spending_policy is not None else None,
             "build_expires_at": build.expires_at if build is not None else None,
             "approvals": [dataclasses.asdict(change) for change in simulation.approvals] if simulation is not None else [],
             "action_count": len(actions),
             "actions": actions,
             "simulation_passed": simulation.passed if simulation is not None else None,
             "simulation_warnings": list(simulation.warnings) if simulation is not None else [],
+            "simulation_guards": list(simulation.guards) if simulation is not None else [],
+            "simulation_fees": list(simulation.fees) if simulation is not None else [],
+            "estimated_svm_network_fee_lamports": (
+                str(svm_fee) if svm_fee is not None else None
+            ),
+            "max_svm_network_fee_lamports": (
+                str(cfg.max_svm_network_fee_lamports) if cfg.max_svm_network_fee_lamports is not None else None
+            ),
             "balance_changes": (
                 [dataclasses.asdict(change) for change in simulation.balance_changes] if simulation is not None else []
             ),

--- a/services/onchain_preparation.py
+++ b/services/onchain_preparation.py
@@ -1,9 +1,27 @@
 """Aomi-side market preparation; this service never creates or commits an executor."""
-from typing import Any, Dict
+import asyncio
+from typing import Any, Awaitable, Callable, Dict, TypeVar
 
 from aomi.pipeline.client import PipelineClient
+from aomi.pipeline.errors import PipelineError
 
 from models.onchain_preparation import OnchainPreparationRequest
+
+
+T = TypeVar("T")
+
+
+async def admitted_read(call: Callable[[], Awaitable[T]]) -> T:
+    """Only retry an explicit refusal before dispatch; never replay an unknown outcome."""
+    delays = (0.15, 0.3, 0.6, 1.2, 2.4)
+    for attempt in range(len(delays) + 1):
+        try:
+            return await call()
+        except PipelineError as exc:
+            if exc.status != 409 or exc.code != "operation_in_flight" or attempt == len(delays):
+                raise
+            await asyncio.sleep(delays[attempt])
+    raise AssertionError("unreachable")
 
 
 async def prepare_onchain(
@@ -11,7 +29,7 @@ async def prepare_onchain(
 ) -> Dict[str, Any]:
     if type(application_id) is not int or application_id <= 0:
         raise ValueError("Configure the registered Aomi preparation application ID before preparing markets")
-    context = await client.svm_context()
+    context = await admitted_read(client.svm_context)
     wallet = context.get("address")
     cluster = context.get("cluster")
     if not isinstance(wallet, str) or not wallet or cluster != "mainnet-beta":
@@ -21,9 +39,9 @@ async def prepare_onchain(
         if arguments.get("wallet", wallet) != wallet:
             raise ValueError("Requested wallet does not match the Aomi signing wallet")
         arguments["wallet"] = wallet
-    result = await client.invoke(
+    result = await admitted_read(lambda: client.invoke(
         "solana-defi", f"solana_defi_{request.operation}", arguments, application_id=application_id
-    )
+    ))
     if result.build is not None:
         raise ValueError("Preparation unexpectedly staged a transaction")
     payload = result.result

--- a/services/onchain_preparation.py
+++ b/services/onchain_preparation.py
@@ -1,0 +1,34 @@
+"""Aomi-side market preparation; this service never creates or commits an executor."""
+from typing import Any, Dict
+
+from aomi.pipeline.client import PipelineClient
+
+from models.onchain_preparation import OnchainPreparationRequest
+
+
+async def prepare_onchain(
+    request: OnchainPreparationRequest, client: PipelineClient, *, application_id: int | None
+) -> Dict[str, Any]:
+    if type(application_id) is not int or application_id <= 0:
+        raise ValueError("Configure the registered Aomi preparation application ID before preparing markets")
+    context = await client.svm_context()
+    wallet = context.get("address")
+    cluster = context.get("cluster")
+    if not isinstance(wallet, str) or not wallet or cluster != "mainnet-beta":
+        raise ValueError("Connect a Solana mainnet wallet before preparing these markets")
+    arguments = dict(request.arguments)
+    if request.operation != "venues":
+        if arguments.get("wallet", wallet) != wallet:
+            raise ValueError("Requested wallet does not match the Aomi signing wallet")
+        arguments["wallet"] = wallet
+    result = await client.invoke(
+        "solana-defi", f"solana_defi_{request.operation}", arguments, application_id=application_id
+    )
+    if result.build is not None:
+        raise ValueError("Preparation unexpectedly staged a transaction")
+    payload = result.result
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid Aomi preparation response")
+    if request.operation != "venues" and (payload.get("wallet") != wallet or payload.get("cluster") != cluster):
+        raise ValueError("Preparation wallet or network does not match the connected account")
+    return {"wallet": wallet, "cluster": cluster, "result": payload}

--- a/setup.sh
+++ b/setup.sh
@@ -541,6 +541,12 @@ DATABASE_URL=postgresql+asyncpg://hbot:hummingbot-api@localhost:5432/hummingbot_
 GATEWAY_URL=http://localhost:15888
 GATEWAY_PASSPHRASE=$CONFIG_PASSWORD
 
+# Aomi Pipeline (optional; needed by the onchain_executor). AOMI_TOKEN is a bearer with
+# pipeline:execute (plus custody:delegate to commit); leave it empty to keep the executor
+# disabled, or point AOMI_TOKEN_FILE at a file holding the token instead.
+AOMI_URL=https://chat.aomi.dev
+AOMI_TOKEN=
+
 # Paths
 BOTS_PATH=$(pwd)
 

--- a/setup.sh
+++ b/setup.sh
@@ -546,6 +546,8 @@ GATEWAY_PASSPHRASE=$CONFIG_PASSWORD
 # disabled, or point AOMI_TOKEN_FILE at a file holding the token instead.
 AOMI_URL=https://chat.aomi.dev
 AOMI_TOKEN=
+# Optional operator-owned JSON policy; grants are enforced before durable execution admission.
+AOMI_LENDING_POLICY_FILE=
 
 # Paths
 BOTS_PATH=$(pwd)

--- a/setup.sh
+++ b/setup.sh
@@ -738,6 +738,8 @@ AOMI_URL=https://chat.aomi.dev
 AOMI_TOKEN=
 # Optional operator-owned JSON policy; grants are enforced before durable execution admission.
 AOMI_LENDING_POLICY_FILE=
+# Registered solana-defi app ID for market preparation (uncomment after registration).
+# AOMI_PREPARATION_APPLICATION_ID=123
 
 # Paths
 BOTS_PATH=$(pwd)

--- a/test/test_lending_policy.py
+++ b/test/test_lending_policy.py
@@ -1,0 +1,112 @@
+import pytest
+
+from models.onchain_executor import OnchainExecutorConfig
+from services.lending_policy import LendingPolicy
+from services.lending_positions import BASE_AAVE_USDC
+
+WALLET = "0x" + "3" * 40
+
+
+def policy(**over):
+    return LendingPolicy({
+        "wallet": WALLET, "account_name": "master_account", "controller_limits_raw": {"a": "100", "b": "100"},
+        "max_total_supply_raw": "150", "max_action_raw": "100", "max_gas_quote": "1", **over,
+    })
+
+
+def config(amount=60, action="supply", **over):
+    return OnchainExecutorConfig(chain_id=8453, mode="lending", lending={
+        "chain_id": 8453, "pool": BASE_AAVE_USDC[1], "asset": BASE_AAVE_USDC[2],
+        "wallet": WALLET, "amount": amount, "action": action,
+    }, max_gas_quote="1", **over)
+
+
+def record(ident="first", amount=60, controller="a", action="supply", confirmed=False):
+    return {"executor_id": ident, "account_name": "master_account", "controller_id": controller,
+            "status": "RUNNING", "config": config(amount, action).model_dump(mode="json"),
+            "custom_info": {"committed": confirmed, "tx_hashes": ["0x" + ident.encode().hex().ljust(64, "0")]}}
+
+
+def admit(cfg, records=(), controller="a", account="master_account", rules=None):
+    return (rules or policy()).admit(cfg, account, controller, records)
+
+
+def test_pending_and_completed_supplies_both_consume_the_controller_grant():
+    for confirmed in (False, True):
+        history = [record(confirmed=confirmed)]
+        admit(config(40), history)
+        with pytest.raises(ValueError, match="remaining"):
+            admit(config(41), history)
+
+
+def test_total_limit_is_shared_across_controllers_and_hummingbot_accounts():
+    history = [record(amount=100)]
+    admit(config(50), history, "b")
+    with pytest.raises(ValueError, match="remaining"):
+        admit(config(51), history, "b")
+    history[0]["account_name"] = "different_account"
+    with pytest.raises(ValueError, match="remaining"):
+        admit(config(51), history, "b")
+
+
+def test_withdrawal_does_not_spend_another_controllers_position_or_pending_deposit():
+    with pytest.raises(ValueError, match="Withdrawal"):
+        admit(config(1, "withdraw"), [record()])
+    with pytest.raises(ValueError, match="Withdrawal"):
+        admit(config(1, "withdraw"), [record(confirmed=True)], "b")
+    history = [record(confirmed=True), record("withdraw", 20, action="withdraw")]
+    admit(config(40, "withdraw"), history)
+    with pytest.raises(ValueError, match="Withdrawal"):
+        admit(config(41, "withdraw"), history)
+
+
+def test_only_confirmed_withdrawals_release_supply_capacity():
+    history = [record(amount=100, confirmed=True), record("withdraw", 60, action="withdraw")]
+    with pytest.raises(ValueError, match="remaining"):
+        admit(config(1), history)
+    history[1]["custom_info"]["committed"] = True
+    admit(config(60), history)
+
+
+def test_policy_refuses_changed_authority_ungranted_controller_and_untracked_history():
+    with pytest.raises(ValueError, match="grant"):
+        admit(config(), controller="stranger")
+    with pytest.raises(ValueError, match="grant"):
+        admit(config(), account="other")
+    for field in ("wallet", "pool", "asset"):
+        cfg = config().model_dump()
+        cfg["lending"][field] = "0x" + "4" * 40
+        with pytest.raises(ValueError, match="approved"):
+            admit(OnchainExecutorConfig(**cfg))
+    with pytest.raises(ValueError, match="reconciliation"):
+        admit(config(), [{"config": {"mode": "calls", "commit": True}}])
+
+
+def test_policy_limits_action_and_gas_even_for_explicit_creates():
+    with pytest.raises(ValueError, match="action or gas"):
+        admit(config(101))
+    for gas in (None, "2"):
+        cfg = config().model_dump()
+        cfg["max_gas_quote"] = gas
+        with pytest.raises(ValueError, match="action or gas"):
+            admit(OnchainExecutorConfig(**cfg))
+
+
+def test_policy_exact_raw_units_and_fail_closed_configuration(tmp_path):
+    for bad in (0, "0", "-1", "1.0", str(2 ** 256 - 1)):
+        with pytest.raises(ValueError):
+            policy(max_total_supply_raw=bad)
+    with pytest.raises(ValueError):
+        policy(max_gas_quote="NaN")
+    with pytest.raises(ValueError):
+        policy(extra="unexpected")
+    assert LendingPolicy.load("") is None
+    with pytest.raises(FileNotFoundError):
+        LendingPolicy.load(str(tmp_path / "missing.json"))
+    assert policy().report()["max_total_supply_raw"] == "150"
+
+
+def test_dry_runs_reserve_no_capital():
+    history = [record(amount=100)]
+    history[0]["config"]["commit"] = False
+    admit(config(100), history)

--- a/test/test_lending_policy_admission.py
+++ b/test/test_lending_policy_admission.py
@@ -1,0 +1,82 @@
+"""Real PostgreSQL concurrency test; only an explicitly named isolated test database."""
+import asyncio
+import json
+import os
+import uuid
+from test.test_lending_policy import config
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from config import settings
+from database import AsyncDatabaseManager, ExecutorRepository
+from database.models import ExecutorRecord
+from services.executor_service import ExecutorService
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("isolation", ["READ COMMITTED", "REPEATABLE READ"])
+async def test_concurrent_admission_and_restart_keep_the_same_durable_reservation(tmp_path, monkeypatch, isolation):
+    url = os.environ.get("AOMI_POLICY_TEST_DATABASE_URL", "")
+    if not url:
+        pytest.skip("AOMI_POLICY_TEST_DATABASE_URL not set")
+    parsed = make_url(url)
+    assert parsed.host in {"127.0.0.1", "localhost"}
+    assert parsed.database.startswith("hummingbot_policy_check_")
+    db = AsyncDatabaseManager(url)
+    db.async_session = async_sessionmaker(db.engine.execution_options(isolation_level=isolation), expire_on_commit=False)
+    async with db.engine.begin() as connection:
+        await connection.run_sync(lambda conn: ExecutorRecord.__table__.create(conn, checkfirst=True))
+    policy_file = tmp_path / "policy.json"
+    policy_file.write_text(json.dumps({
+        "wallet": "0x" + "3" * 40, "account_name": "master_account", "controller_limits_raw": {"a": "100", "b": "100"},
+        "max_total_supply_raw": "100", "max_action_raw": "100", "max_gas_quote": "1",
+    }))
+    monkeypatch.setattr(settings.aomi, "lending_policy_file", str(policy_file))
+    original = ExecutorRepository.get_executors
+
+    async def slow_read(self, **kwargs):
+        rows = await original(self, **kwargs)
+        await asyncio.sleep(0.05)  # Without the lock, both writers read the same empty history.
+        return rows
+
+    monkeypatch.setattr(ExecutorRepository, "get_executors", slow_read)
+    ids = [str(uuid.uuid4()) for _ in range(3)]
+
+    def service():
+        instance = object.__new__(ExecutorService)
+        instance.db_manager = db
+        instance._executor_metadata = {}
+        return instance
+
+    async def submit(instance, ident, controller):
+        cfg = config(60, require_lending_policy=True)
+        instance._executor_metadata[ident] = {
+            "executor_type": "onchain_executor", "account_name": "master_account", "controller_id": controller,
+            "connector_name": "base", "trading_pair": "USDC-USDT", "config": cfg.model_dump(mode="json"),
+        }
+        await instance._persist_executor_created(ident, SimpleNamespace(config=cfg, status=SimpleNamespace(name="NOT_STARTED")))
+
+    try:
+        # Separate service instances model separate API processes sharing PostgreSQL.
+        results = await asyncio.gather(submit(service(), ids[0], "a"), submit(service(), ids[1], "b"), return_exceptions=True)
+        assert sum(result is None for result in results) == 1
+        assert sum(isinstance(result, ValueError) for result in results) == 1
+        # No in-memory state survives in this third instance; the DB reservation still applies.
+        with pytest.raises(ValueError, match="remaining"):
+            await submit(service(), ids[2], "a")
+        monkeypatch.setattr(settings.aomi, "lending_policy_file", "")
+        with pytest.raises(ValueError, match="active operator policy"):
+            await submit(service(), ids[2], "a")
+        async with db.get_session_context() as session:
+            records = await original(ExecutorRepository(session), executor_type="onchain_executor", limit=None)
+            assert len(records) == 1
+            assert json.loads(records[0].config)["lending"]["amount"] == 60
+    finally:
+        async with db.get_session_context() as session:
+            await session.execute(delete(ExecutorRecord).where(ExecutorRecord.executor_id.in_(ids)))
+        await db.engine.dispose()

--- a/test/test_lending_positions.py
+++ b/test/test_lending_positions.py
@@ -1,0 +1,136 @@
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.lending_positions import BASE_AAVE_USDC, LendingPosition
+
+
+def row(executor_id="supply", action="supply", amount=100_000_000, **info):
+    return {
+        "executor_id": executor_id, "account_name": "master_account", "controller_id": "reserves",
+        "status": "TERMINATED", "config": {"mode": "lending", "commit": True, "lending": {
+            "chain_id": 8453, "pool": "0x" + "1" * 40, "asset": "0x" + "2" * 40,
+            "wallet": "0x" + "3" * 40, "action": action, "amount": amount,
+        }}, "custom_info": {"committed": True, "tx_hashes": ["0x" + "a" * 64], **info},
+    }
+
+
+def test_completed_supply_survives_history_reconstruction_and_preserves_precision():
+    history = [row(amount=123456789012345678901234567890)]
+    position = LendingPosition.from_executors(history)[0]
+    assert position["net_contributed_raw"] == "123456789012345678901234567890"
+    assert position["requires_balance_reconciliation"] is True
+    assert LendingPosition.from_executors(deepcopy(history)) == [position]
+
+
+def test_confirmed_withdrawals_reduce_contributions_but_never_claim_a_closed_position():
+    history = [row(), row("withdraw", "withdraw", 100_000_001, tx_hashes=["0x" + "b" * 64])]
+    position = LendingPosition.from_executors(history)[0]
+    assert position["net_contributed_raw"] == "0"
+    assert position["withdrawn_raw"] == "100000001"
+    assert position["requires_balance_reconciliation"] is True
+    assert "pnl" not in position
+
+
+def test_pending_and_failed_unknown_attempts_reserve_capital_and_do_not_reduce_contributions():
+    supply = row("pending", amount=50, committed=False, commit_attempted=True)
+    withdraw = row("withdraw", "withdraw", 20, committed=False)
+    position = LendingPosition.from_executors([row(), supply, withdraw])[0]
+    assert position["net_contributed_raw"] == "100000000"
+    assert position["pending_supply_raw"] == "50"
+    assert position["pending_withdraw_raw"] == "20"
+    assert position["unresolved_executor_ids"] == ["pending", "withdraw"]
+
+
+def test_dry_runs_and_proven_unsent_failures_allocate_nothing():
+    dry = row()
+    dry["config"]["commit"] = False
+    failed = row("failed", committed=False, commit_attempted=False)
+    assert LendingPosition.from_executors([dry, failed]) == []
+
+
+def test_idempotent_receipt_replay_is_counted_once():
+    position = LendingPosition.from_executors([row(), row("replay")])[0]
+    assert position["supplied_raw"] == "100000000"
+    assert position["executor_ids"] == ["replay", "supply"]
+
+
+def test_receipts_cannot_be_reassigned_to_a_different_controller_or_amount():
+    for changed in [row("changed", amount=1), row("changed")]:
+        changed["controller_id"] = "another-agent"
+        with pytest.raises(ValueError, match="conflicting receipt"):
+            LendingPosition.from_executors([row(), changed])
+
+
+def test_partial_receipt_overlap_cannot_double_count_a_batch():
+    with pytest.raises(ValueError, match="conflicting receipt"):
+        LendingPosition.from_executors([row(), row("partial", tx_hashes=["0x" + "a" * 64, "0x" + "b" * 64])])
+
+
+@pytest.mark.parametrize("hashes", [[], ["bad"], None])
+def test_confirmed_history_without_receipts_is_not_treated_as_a_balance(hashes):
+    with pytest.raises(ValueError, match="missing transaction receipts"):
+        LendingPosition.from_executors([row(tx_hashes=hashes)])
+
+
+@pytest.mark.asyncio
+async def test_position_route_fails_closed_when_storage_fails():
+    from fastapi import HTTPException
+
+    from routers.executors import get_lending_positions
+
+    service = SimpleNamespace(get_lending_positions=AsyncMock(side_effect=RuntimeError("db unavailable")))
+    with pytest.raises(HTTPException) as error:
+        await get_lending_positions(service)
+    assert error.value.status_code == 503
+    assert "db unavailable" not in error.value.detail
+
+
+@pytest.mark.asyncio
+async def test_wallet_balance_is_not_distributed_or_double_fetched_between_controllers():
+    first, second = row(), row("other", tx_hashes=["0x" + "b" * 64])
+    second["controller_id"] = "another-agent"
+    for record in (first, second):
+        record["config"]["lending"].update(pool=BASE_AAVE_USDC[1], asset=BASE_AAVE_USDC[2])
+    positions = LendingPosition.from_executors([first, second])
+    client = SimpleNamespace(evm_token_holdings=AsyncMock(return_value={
+        "chain_id": 8453, "token": "0x4e65fe4dba92790696d040ac24aa414708f5c0ab",
+        "holder": "0x" + "3" * 40, "decimals": 6, "balance_raw": "200000020",
+    }))
+    result = await LendingPosition.read_wallet_balances(positions, client)
+    assert client.evm_token_holdings.await_count == 1
+    assert all(p["wallet_receipt_balance_raw"] == "200000020" for p in result)
+    assert all(p["balance_scope"] == "wallet" for p in result)
+    assert all(p["net_contributed_raw"] == "100000000" for p in result)
+
+
+@pytest.mark.asyncio
+async def test_wrong_wallet_balance_is_rejected():
+    record = row()
+    record["config"]["lending"].update(pool=BASE_AAVE_USDC[1], asset=BASE_AAVE_USDC[2])
+    client = SimpleNamespace(evm_token_holdings=AsyncMock(return_value={
+        "chain_id": 8453, "token": "0x4e65fe4dba92790696d040ac24aa414708f5c0ab",
+        "holder": "0x" + "4" * 40, "decimals": 6, "balance_raw": "0",
+    }))
+    with pytest.raises(ValueError, match="does not match"):
+        await LendingPosition.read_wallet_balances(LendingPosition.from_executors([record]), client)
+
+
+@pytest.mark.asyncio
+async def test_service_requires_full_history_and_propagates_a_database_failure(monkeypatch):
+    from contextlib import asynccontextmanager
+
+    from services.executor_service import ExecutorService
+
+    @asynccontextmanager
+    async def session_context():
+        yield object()
+
+    repository = SimpleNamespace(get_executors=AsyncMock(side_effect=RuntimeError("storage down")))
+    monkeypatch.setattr("services.executor_service.ExecutorRepository", lambda session: repository)
+    service = SimpleNamespace(db_manager=SimpleNamespace(get_session_context=session_context))
+    with pytest.raises(RuntimeError, match="storage down"):
+        await ExecutorService.get_lending_positions(service)
+    repository.get_executors.assert_awaited_once_with(executor_type="onchain_executor", limit=None)

--- a/test/test_onchain_executor_config.py
+++ b/test/test_onchain_executor_config.py
@@ -1,0 +1,141 @@
+"""OnchainExecutorConfig validates its two modes and derives what the executors table needs.
+
+An onchain executor has no connector. The executors table still requires ``connector_name``
+and ``trading_pair`` (NOT NULL), so the config derives both from ``chain_id`` when the caller
+leaves them out, and the record reads like any other executor's.
+"""
+import pytest
+
+pytest.importorskip("hummingbot")
+
+from pydantic import ValidationError  # noqa: E402
+
+from models.executors import EXECUTOR_TYPES  # noqa: E402
+from models.onchain_executor import OnchainExecutorConfig  # noqa: E402
+
+WALLET = "0x1111111111111111111111111111111111111111"
+A_CALL = {"to": WALLET, "value": "0", "data": {"signature": "", "args": [], "raw": ""}, "description": "self"}
+
+
+def test_operation_mode_requires_an_operation():
+    with pytest.raises(ValidationError, match="requires 'operation'"):
+        OnchainExecutorConfig(chain_id=8453, mode="operation")
+
+
+def test_calls_mode_requires_calls():
+    with pytest.raises(ValidationError, match="non-empty 'calls'"):
+        OnchainExecutorConfig(chain_id=8453, mode="calls")
+    with pytest.raises(ValidationError, match="non-empty 'calls'"):
+        OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[])
+
+
+def test_the_modes_are_exclusive():
+    with pytest.raises(ValidationError, match="does not take 'calls'"):
+        OnchainExecutorConfig(chain_id=8453, mode="operation", operation="transfer", calls=[A_CALL])
+    with pytest.raises(ValidationError, match="does not take 'operation'"):
+        OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL], operation="transfer")
+    with pytest.raises(ValidationError, match="does not take 'operation'"):
+        OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL], arguments={"x": 1})
+
+
+def test_svm_cannot_stage_raw_calls():
+    with pytest.raises(ValidationError, match="svm"):
+        OnchainExecutorConfig(chain="svm", chain_id=1, mode="calls", calls=[A_CALL])
+
+
+def test_chain_id_must_be_positive():
+    with pytest.raises(ValidationError):
+        OnchainExecutorConfig(chain_id=0, mode="calls", calls=[A_CALL])
+
+
+def test_base_derives_its_record_fields():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL])
+
+    assert cfg.connector_name == "base"
+    assert cfg.trading_pair == "ETH-ETH"
+
+
+def test_polygon_pays_gas_in_pol():
+    cfg = OnchainExecutorConfig(chain_id=137, mode="calls", calls=[A_CALL])
+
+    assert cfg.connector_name == "polygon"
+    assert cfg.trading_pair == "POL-POL"
+
+
+def test_an_unknown_chain_still_gets_a_name():
+    cfg = OnchainExecutorConfig(chain_id=999999, mode="calls", calls=[A_CALL])
+
+    assert cfg.connector_name == "evm-999999"
+    assert cfg.trading_pair == "ETH-ETH"
+
+
+def test_explicit_record_fields_are_kept():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL], connector_name="base-l2", trading_pair="X-Y")
+
+    assert cfg.connector_name == "base-l2"
+    assert cfg.trading_pair == "X-Y"
+
+
+def test_chain_id_is_injected_into_calls_that_omit_it():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL, {**A_CALL, "chain_id": 1}])
+
+    assert [c["chain_id"] for c in cfg.calls] == [8453, 1]
+    assert "chain_id" not in A_CALL  # the caller's dict is not mutated
+
+
+def test_a_bare_operation_resolves_into_the_app_catalog():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", app="uniswap", operation="swap")
+
+    assert cfg.operation_path == "/v1/pipeline/apps/uniswap/operations/swap"
+
+
+def test_an_absolute_operation_path_is_kept():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", operation="/v1/pipeline/skills/erc20/operations/transfer")
+
+    assert cfg.operation_path == "/v1/pipeline/skills/erc20/operations/transfer"
+
+
+def test_defaults():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL])
+
+    assert cfg.type == "onchain_executor"
+    assert cfg.chain == "evm"
+    assert cfg.app == "default"
+    assert cfg.skills == []
+    assert cfg.commit is True
+    assert cfg.keep_position is False
+    assert cfg.timeout_sec == 120
+    assert cfg.max_gas_quote is None
+    assert cfg.notional_quote is None
+    assert cfg.id  # ExecutorConfigBase assigns one
+    assert isinstance(cfg.timestamp, float)  # ExecutorInfo needs one even when the caller gave none
+
+
+def test_the_type_is_registered():
+    from services.executor_service import ExecutorService
+    from services.onchain_executor import OnchainExecutor
+
+    assert ExecutorService.EXECUTOR_REGISTRY["onchain_executor"] == (OnchainExecutor, OnchainExecutorConfig)
+
+
+def test_the_type_is_in_the_api_literal():
+    assert "onchain_executor" in EXECUTOR_TYPES.__args__
+
+
+def test_the_schema_endpoint_reads_the_config():
+    """/executors/types/onchain_executor/config is derived from the JSON schema."""
+    from routers.executors import _extract_field_info
+
+    schema = OnchainExecutorConfig.model_json_schema()
+    fields = {f["name"]: f for f in _extract_field_info(schema, schema.get("$defs", {}))}
+
+    assert fields["chain_id"]["required"] is True
+    assert fields["chain_id"]["constraints"]["minimum"] == 1
+    assert fields["mode"]["type"] == "enum"
+    assert set(fields["mode"]["enum_values"]) == {"operation", "calls"}
+    assert fields["mode"]["required"] is True
+    assert fields["commit"]["default"] is True
+    assert fields["commit"]["required"] is False
+    assert fields["calls"]["required"] is False
+    for name in ("chain_id", "mode", "calls", "operation", "arguments", "max_gas_quote", "commit"):
+        assert fields[name].get("description"), f"{name} has no description for the schema endpoint"

--- a/test/test_onchain_executor_config.py
+++ b/test/test_onchain_executor_config.py
@@ -139,3 +139,37 @@ def test_the_schema_endpoint_reads_the_config():
     assert fields["calls"]["required"] is False
     for name in ("chain_id", "mode", "calls", "operation", "arguments", "max_gas_quote", "commit"):
         assert fields[name].get("description"), f"{name} has no description for the schema endpoint"
+
+
+def test_a_bare_operation_resolves_into_a_single_named_skill():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", skills=["aave"], operation="aave_supply")
+    assert cfg.operation_path == "/v1/pipeline/skills/aave/operations/aave_supply"
+
+
+def test_two_skills_leave_a_bare_operation_in_the_app_catalog():
+    cfg = OnchainExecutorConfig(
+        chain_id=8453, mode="operation", app="default", skills=["aave", "lido"], operation="call_v4_swap"
+    )
+    assert cfg.operation_path == "/v1/pipeline/apps/default/operations/call_v4_swap"
+
+
+def test_a_named_app_wins_over_a_single_skill():
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", app="erc20", skills=["gas"], operation="transfer")
+    assert cfg.operation_path == "/v1/pipeline/apps/erc20/operations/transfer"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["ask_authorization", "schedule_cron", "evm_commit_txs", "svm_stage_ix", "dummy_echo", "get_account_info",
+     "/v1/pipeline/apps/default/operations/brave_search"],
+)
+def test_harness_lifecycle_read_and_test_operations_are_refused(operation):
+    with pytest.raises(ValidationError) as exc:
+        OnchainExecutorConfig(chain_id=8453, mode="operation", operation=operation)
+    assert "cannot be built by this executor" in str(exc.value)
+
+
+@pytest.mark.parametrize("operation", ["call_v4_swap", "lifi_prepare_swap_tx", "prepare_lido_claim", "aave_supply"])
+def test_executable_operations_are_accepted(operation):
+    cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", operation=operation)
+    assert cfg.operation == operation

--- a/test/test_onchain_executor_config.py
+++ b/test/test_onchain_executor_config.py
@@ -173,3 +173,11 @@ def test_harness_lifecycle_read_and_test_operations_are_refused(operation):
 def test_executable_operations_are_accepted(operation):
     cfg = OnchainExecutorConfig(chain_id=8453, mode="operation", operation=operation)
     assert cfg.operation == operation
+
+
+def test_svm_records_derive_solana_fields():
+    cfg = OnchainExecutorConfig(chain="svm", chain_id=1, mode="operation", operation="jupiter_prepare_swap")
+    assert cfg.connector_name == "solana-mainnet-beta"
+    assert cfg.trading_pair == "SOL-SOL"
+    devnet = OnchainExecutorConfig(chain="svm", chain_id=1, cluster="devnet", mode="operation", operation="jupiter_prepare_swap")
+    assert devnet.connector_name == "solana-devnet"

--- a/test/test_onchain_executor_config.py
+++ b/test/test_onchain_executor_config.py
@@ -22,6 +22,18 @@ def test_operation_mode_requires_an_operation():
         OnchainExecutorConfig(chain_id=8453, mode="operation")
 
 
+@pytest.mark.parametrize("value", [-1, 0.5, True, "5000"])
+def test_svm_fee_limit_requires_nonnegative_integer_lamports(value):
+    with pytest.raises(ValidationError):
+        OnchainExecutorConfig(chain="svm", chain_id=1, mode="operation", operation="deposit",
+                              max_svm_network_fee_lamports=value)
+
+
+def test_svm_fee_limit_cannot_be_applied_to_evm():
+    with pytest.raises(ValidationError, match="requires svm"):
+        OnchainExecutorConfig(chain_id=8453, mode="calls", calls=[A_CALL], max_svm_network_fee_lamports=5000)
+
+
 def test_calls_mode_requires_calls():
     with pytest.raises(ValidationError, match="non-empty 'calls'"):
         OnchainExecutorConfig(chain_id=8453, mode="calls")
@@ -132,7 +144,7 @@ def test_the_schema_endpoint_reads_the_config():
     assert fields["chain_id"]["required"] is True
     assert fields["chain_id"]["constraints"]["minimum"] == 1
     assert fields["mode"]["type"] == "enum"
-    assert set(fields["mode"]["enum_values"]) == {"operation", "calls", "lending"}
+    assert set(fields["mode"]["enum_values"]) == {"operation", "calls", "instructions", "lending"}
     assert fields["mode"]["required"] is True
     assert fields["commit"]["default"] is True
     assert fields["commit"]["required"] is False
@@ -181,3 +193,15 @@ def test_svm_records_derive_solana_fields():
     assert cfg.trading_pair == "SOL-SOL"
     devnet = OnchainExecutorConfig(chain="svm", chain_id=1, cluster="devnet", mode="operation", operation="jupiter_prepare_swap")
     assert devnet.connector_name == "solana-devnet"
+
+
+@pytest.mark.parametrize("overrides", [
+    {"chain": "evm"}, {"instructions": []}, {"instructions": [{"instructions": []}]},
+    {"calls": [A_CALL]}, {"operation": "swap"}, {"arguments": {}},
+    {"mode": "operation", "operation": "swap"},
+])
+def test_instruction_mode_rejects_ambiguous_or_empty_bundles(overrides):
+    values = dict(chain="svm", chain_id=1, mode="instructions",
+                  instructions=[{"description": "test", "instructions": [{"program_id": "p"}]}])
+    with pytest.raises(ValidationError):
+        OnchainExecutorConfig(**{**values, **overrides})

--- a/test/test_onchain_executor_config.py
+++ b/test/test_onchain_executor_config.py
@@ -132,7 +132,7 @@ def test_the_schema_endpoint_reads_the_config():
     assert fields["chain_id"]["required"] is True
     assert fields["chain_id"]["constraints"]["minimum"] == 1
     assert fields["mode"]["type"] == "enum"
-    assert set(fields["mode"]["enum_values"]) == {"operation", "calls"}
+    assert set(fields["mode"]["enum_values"]) == {"operation", "calls", "lending"}
     assert fields["mode"]["required"] is True
     assert fields["commit"]["default"] is True
     assert fields["commit"]["required"] is False

--- a/test/test_onchain_executor_e2e.py
+++ b/test/test_onchain_executor_e2e.py
@@ -1,0 +1,164 @@
+"""Live: an onchain executor commits a 0-value self-transfer on Base through a running API.
+
+Needs a running hummingbot-api whose environment carries an Aomi bearer, plus:
+
+    API_URL, API_USER, API_PASSWORD           the API and its basic auth
+    AOMI_TOKEN or AOMI_TOKEN_FILE             the same bearer, so the test can discover the wallet
+    AOMI_E2E_WALLET (optional)                the kernel wallet; discovered through the pipeline when unset
+
+Run with: pytest test/test_onchain_executor_e2e.py -v -m integration
+"""
+import asyncio
+import os
+import time
+
+import pytest
+
+pytest.importorskip("aomi")
+
+from aomi.pipeline.client import PipelineClient  # noqa: E402
+
+BASE = 8453
+USDC_ON_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+POLL_SECONDS = 2
+DEADLINE_SECONDS = 180
+
+
+def _env(name):
+    value = os.environ.get(name, "").strip()
+    if not value:
+        pytest.skip(f"{name} not set")
+    return value
+
+
+def _aomi_token():
+    token_file = os.environ.get("AOMI_TOKEN_FILE", "").strip()
+    if token_file:
+        with open(token_file, encoding="utf-8") as handle:
+            return handle.read().strip()
+    return _env("AOMI_TOKEN")
+
+
+@pytest.fixture
+def api():
+    aiohttp = pytest.importorskip("aiohttp")
+    url = _env("API_URL").rstrip("/")
+    auth = aiohttp.BasicAuth(_env("API_USER"), _env("API_PASSWORD"))
+    return url, auth
+
+
+@pytest.fixture
+def aomi_url():
+    return os.environ.get("AOMI_URL", "https://chat.aomi.dev").rstrip("/")
+
+
+async def _wallet(aomi_url):
+    wallet = os.environ.get("AOMI_E2E_WALLET", "").strip()
+    if wallet:
+        return wallet
+    async with PipelineClient(aomi_url, _aomi_token()) as client:
+        holdings = await client.evm_token_holdings(BASE, USDC_ON_BASE)
+    holder = holdings.get("holder") if isinstance(holdings, dict) else None
+    if not holder:
+        pytest.skip(f"could not discover the kernel wallet from token-holdings: {holdings!r}")
+    return holder
+
+
+async def _create(session, api, wallet, **config):
+    url, auth = api
+    payload = {
+        "account_name": "master_account",
+        "controller_id": "e2e",
+        "executor_config": {
+            "type": "onchain_executor",
+            "chain_id": BASE,
+            "mode": "calls",
+            "calls": [PipelineClient.native_transfer(wallet, chain_id=BASE, value="0", description="e2e self-transfer")],
+            **config,
+        },
+    }
+    async with session.post(f"{url}/executors/", json=payload, auth=auth) as response:
+        body = await response.json()
+        assert response.status in (200, 201), body
+        return body["executor_id"]
+
+
+async def _wait_for_termination(session, api, executor_id):
+    """Poll until TERMINATED; while RUNNING, the log endpoint must already have entries."""
+    url, auth = api
+    logs_seen_while_running = False
+    deadline = time.monotonic() + DEADLINE_SECONDS
+    while time.monotonic() < deadline:
+        async with session.get(f"{url}/executors/{executor_id}", auth=auth) as response:
+            detail = await response.json()
+            assert response.status == 200, detail
+        if detail["status"] == "TERMINATED":
+            return detail, logs_seen_while_running
+        async with session.get(f"{url}/executors/{executor_id}/logs", auth=auth) as response:
+            logs = await response.json()
+            if response.status == 200 and logs.get("total_count", 0) > 0:
+                logs_seen_while_running = True
+        await asyncio.sleep(POLL_SECONDS)
+    pytest.fail(f"executor {executor_id} did not terminate within {DEADLINE_SECONDS}s")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_the_config_schema_describes_the_executor(api):
+    import aiohttp
+
+    url, auth = api
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{url}/executors/types/onchain_executor/config", auth=auth) as response:
+            body = await response.json()
+            assert response.status == 200, body
+
+    names = {field["name"] for field in body["fields"]}
+    assert {"chain_id", "mode", "calls"} <= names
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_a_self_transfer_on_base_is_committed(api, aomi_url):
+    import aiohttp
+
+    wallet = await _wallet(aomi_url)
+    async with aiohttp.ClientSession() as session:
+        executor_id = await _create(session, api, wallet)
+        detail, logs_seen = await _wait_for_termination(session, api, executor_id)
+
+    custom_info = detail["custom_info"]
+    assert logs_seen, "GET /executors/{id}/logs stayed empty while the executor ran"
+    assert custom_info["wallet_address"].lower() == wallet.lower()
+    error = custom_info.get("error") or {}
+    if (
+        detail["close_type"] == "FAILED"
+        and error.get("backend_code") == "pipeline_commit_failed"
+        and os.environ.get("AOMI_E2E_REQUIRE_COMMIT", "").strip() in ("", "0", "false")
+    ):
+        pytest.skip(
+            f"staging could not sign/broadcast for {wallet}: {error.get('backend_code')} "
+            f"(request {error.get('request_id')}); the executor recorded the failure; "
+            "set AOMI_E2E_REQUIRE_COMMIT=1 to fail instead"
+        )
+    assert detail["close_type"] == "COMPLETED", detail
+    assert custom_info["committed"] is True
+    assert custom_info["tx_hashes"], custom_info
+    print(f"\nonchain_executor {executor_id} committed on Base: {custom_info['tx_hashes'][0]}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_a_dry_run_simulates_without_committing(api, aomi_url):
+    import aiohttp
+
+    wallet = await _wallet(aomi_url)
+    async with aiohttp.ClientSession() as session:
+        executor_id = await _create(session, api, wallet, commit=False)
+        detail, _ = await _wait_for_termination(session, api, executor_id)
+
+    assert detail["close_type"] == "COMPLETED", detail
+    custom_info = detail["custom_info"]
+    assert custom_info["committed"] is False
+    assert custom_info["simulation_passed"] is True
+    assert custom_info["tx_hashes"] == []

--- a/test/test_onchain_executor_is_registered.py
+++ b/test/test_onchain_executor_is_registered.py
@@ -1,0 +1,232 @@
+"""The ExecutorService can create, list and complete an onchain executor.
+
+The executor has no connector, so ``create_executor`` must not try to prepare a market for it:
+its ``connector_name`` is a chain name ("base"), and ``_prepare_market`` would hand that to the
+trading interface to build a Gateway connector. The record still needs a connector and pair
+(both NOT NULL), which the typed config derives.
+"""
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Literal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("hummingbot")
+pytest.importorskip("aomi")
+
+from aomi.pipeline.models import Build, CommitOutcome  # noqa: E402
+from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase  # noqa: E402
+from hummingbot.strategy_v2.models.executors import CloseType  # noqa: E402
+
+from config import AomiSettings  # noqa: E402
+from services.executor_service import ExecutorService  # noqa: E402
+from services.onchain_executor import OnchainExecutor  # noqa: E402
+
+WALLET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+DIGEST = "0x" + "ab" * 32
+TX_HASH = "0x" + "cd" * 32
+A_CALL = {"to": WALLET, "value": "0", "data": {"signature": "", "args": [], "raw": ""}, "description": "self"}
+SIMULATED = {
+    "status": "simulated",
+    "digest": DIGEST,
+    "actions": [{"chain_id": 8453, "from": WALLET, "to": WALLET, "value": "0", "label": "self-transfer"}],
+    "simulation": {"status": "passed", "gas": {"units": "21000", "priceWei": "1", "nativeCost": "0.000021"}},
+}
+CONFIRMED = {"status": "committed", "digest": DIGEST, "result": {"status": "confirmed", "tx_hashes": [TX_HASH]}}
+
+
+class FakePipelineClient:
+    """A /v1/pipeline whose every call succeeds."""
+
+    async def stage_evm(self, actions, *, app=None, skills=None):
+        return Build.from_json({**SIMULATED, "status": "staged"}, "evm")
+
+    async def simulate(self, build):
+        return Build.from_json(dict(SIMULATED), build.chain)
+
+    async def commit(self, build, *, idempotency_key=None):
+        return CommitOutcome.from_response(dict(CONFIRMED))
+
+    async def close(self):
+        pass
+
+
+def _strategy():
+    return SimpleNamespace(connectors={}, current_timestamp=1000.0, _market_data_service=None)
+
+
+def _service(update_interval=0.01):
+    service = ExecutorService.__new__(ExecutorService)
+    service.default_account = "master_account"
+    service.update_interval = update_interval
+    service.max_retries = 3
+    service.db_manager = None
+    service._trading_interfaces = {"master_account": _strategy()}
+    service._trading_service = MagicMock()
+    service._active_executors = {}
+    service._executor_metadata = {}
+    service._positions_held = {}
+    service._lp_position_addresses = {}
+    service._lp_rent_recorded = set()
+    service._lp_rent_retry_after = {}
+    service._log_capture = MagicMock()
+    service._log_capture.get_error_count.return_value = 0
+    service._log_capture.get_last_error.return_value = None
+    service._prepare_market = AsyncMock()
+    service._persist_executor_created = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def fake_pipeline(monkeypatch):
+    """The service builds the executor without a client factory, so the default one is replaced."""
+    import services.onchain_executor as module
+
+    client = FakePipelineClient()
+    monkeypatch.setattr(module.settings, "aomi", AomiSettings(token="test-bearer", token_file=""))
+    monkeypatch.setattr(OnchainExecutor, "_default_client", staticmethod(lambda: client))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_executor_does_not_prepare_a_market_for_a_chain(fake_pipeline):
+    service = _service()
+
+    result = await service.create_executor(
+        {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+        controller_id="e2e",
+    )
+    executor = service._active_executors[result["executor_id"]]
+    await asyncio.wait_for(executor.terminated.wait(), 5)
+
+    service._prepare_market.assert_not_awaited()
+    assert result["executor_type"] == "onchain_executor"
+    assert result["controller_id"] == "e2e"
+    assert executor.close_type == CloseType.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_the_record_gets_the_derived_connector_and_pair(fake_pipeline):
+    """The executors table requires both, and the caller gave neither."""
+    service = _service()
+
+    result = await service.create_executor(
+        {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+    )
+    executor = service._active_executors[result["executor_id"]]
+    await asyncio.wait_for(executor.terminated.wait(), 5)
+
+    assert result["connector_name"] == "base"
+    assert result["trading_pair"] == "ETH-ETH"
+    metadata = service._executor_metadata[result["executor_id"]]
+    assert metadata["connector_name"] == "base"
+    assert metadata["trading_pair"] == "ETH-ETH"
+    assert metadata["executor_type"] == "onchain_executor"
+
+
+@pytest.mark.asyncio
+async def test_executors_with_connectors_still_get_their_market_prepared(monkeypatch):
+    """The USES_CONNECTORS gate defaults open: a class that does not declare it is prepared as before."""
+
+    class DummyConfig(ExecutorConfigBase):
+        type: Literal["dummy_executor"] = "dummy_executor"
+        connector_name: str
+        trading_pair: str
+
+    class DummyExecutor:
+        def __init__(self, strategy, config, update_interval, max_retries):
+            self.config = config
+            self.is_closed = False
+            self.status = SimpleNamespace(name="RUNNING")
+
+        def start(self):
+            pass
+
+    monkeypatch.setitem(ExecutorService.EXECUTOR_REGISTRY, "dummy_executor", (DummyExecutor, DummyConfig))
+    service = _service()
+
+    await service.create_executor({"type": "dummy_executor", "connector_name": "binance", "trading_pair": "BTC-USDT"})
+
+    service._prepare_market.assert_awaited_once_with("master_account", "binance", "BTC-USDT")
+
+
+@pytest.mark.asyncio
+async def test_completion_persists_the_transaction_hashes(fake_pipeline):
+    service = _service()
+    updates = []
+
+    class _Repo:
+        def __init__(self, _session):
+            pass
+
+        async def update_executor(self, **kwargs):
+            updates.append(kwargs)
+
+    @asynccontextmanager
+    async def session_context():
+        yield MagicMock()
+
+    service.db_manager = MagicMock()
+    service.db_manager.get_session_context = session_context
+    import services.executor_service as module
+    monkeypatch_target = module.ExecutorRepository
+    module.ExecutorRepository = _Repo
+    try:
+        result = await service.create_executor(
+            {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+        )
+        executor_id = result["executor_id"]
+        executor = service._active_executors[executor_id]
+        await asyncio.wait_for(executor.terminated.wait(), 5)
+
+        await service._handle_executor_completion(executor_id)
+    finally:
+        module.ExecutorRepository = monkeypatch_target
+
+    assert len(updates) == 1
+    update = updates[0]
+    assert update["executor_id"] == executor_id
+    assert update["status"] == "TERMINATED"
+    assert update["close_type"] == "COMPLETED"
+    final_state = json.loads(update["final_state"])
+    assert final_state["tx_hashes"] == [TX_HASH]
+    assert final_state["committed"] is True
+    assert "transaction_hash" not in final_state
+    assert "orphaned_position" not in final_state
+    assert executor_id not in service._active_executors
+
+
+@pytest.mark.asyncio
+async def test_a_running_onchain_executor_is_listed(fake_pipeline):
+    service = _service(update_interval=0.5)
+
+    result = await service.create_executor(
+        {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+    )
+    executor_id = result["executor_id"]
+    executor = service._active_executors[executor_id]
+    try:
+        formatted = service._format_executor_info(executor_id, executor)
+    finally:
+        executor.early_stop()
+        await asyncio.wait_for(executor.terminated.wait(), 5)
+
+    assert formatted["executor_id"] == executor_id
+    assert formatted["executor_type"] == "onchain_executor"
+    assert formatted["custom_info"]["chain_id"] == 8453
+    json.dumps(formatted, default=str)
+
+
+@pytest.mark.asyncio
+async def test_the_type_listing_offers_it():
+    from routers.executors import get_available_executor_types
+
+    listing = await get_available_executor_types()
+
+    types = {entry["type"]: entry for entry in listing["executor_types"]}
+    assert "onchain_executor" in types
+    assert types["onchain_executor"]["description"]
+    assert types["onchain_executor"]["use_case"]

--- a/test/test_onchain_executor_is_registered.py
+++ b/test/test_onchain_executor_is_registered.py
@@ -230,3 +230,51 @@ async def test_the_type_listing_offers_it():
     assert "onchain_executor" in types
     assert types["onchain_executor"]["description"]
     assert types["onchain_executor"]["use_case"]
+
+
+@pytest.mark.asyncio
+async def test_onchain_never_starts_before_durable_creation(fake_pipeline, monkeypatch):
+    service = _service()
+    started = MagicMock()
+    monkeypatch.setattr(OnchainExecutor, "start", started)
+
+    async def failed_storage(*_):
+        started.assert_not_called()
+        raise RuntimeError("storage unavailable")
+
+    service._persist_executor_created = failed_storage
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await service.create_executor(
+            {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+        )
+    started.assert_not_called()
+    assert service._active_executors == {}
+    assert service._executor_metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_onchain_creation_requires_storage():
+    service = _service()
+    service._executor_metadata["test"] = {"executor_type": "onchain_executor"}
+    with pytest.raises(RuntimeError, match="persistent executor storage"):
+        await ExecutorService._persist_executor_created(service, "test", MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_failed_completion_storage_keeps_result_visible_for_retry(fake_pipeline):
+    service = _service()
+    result = await service.create_executor(
+        {"type": "onchain_executor", "chain_id": 8453, "mode": "calls", "calls": [A_CALL]},
+    )
+    executor_id = result["executor_id"]
+    executor = service._active_executors[executor_id]
+    await asyncio.wait_for(executor.terminated.wait(), 5)
+    service._persist_executor_completed = AsyncMock(side_effect=[RuntimeError("offline"), None])
+    with pytest.raises(RuntimeError, match="offline"):
+        await service._handle_executor_completion(executor_id)
+    assert service._active_executors[executor_id] is executor
+    assert executor.get_custom_info()["tx_hashes"] == [TX_HASH]
+    assert executor_id in service._executor_metadata
+    await service._handle_executor_completion(executor_id)
+    assert executor_id not in service._active_executors
+    assert executor_id not in service._executor_metadata

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -1,0 +1,603 @@
+"""The onchain executor walks stage -> simulate -> risk check -> commit -> confirm, and fails closed.
+
+Every case drives the executor by hand: ``on_start()`` then ``control_task()`` per tick, with
+``evaluate_max_retries()`` after each tick exactly as core's control loop does. The pipeline is
+a scripted fake that records what it was asked and raises on demand, so what is pinned here is
+the executor's own policy: one commit at most, replayed under the same idempotency key; a
+failing simulation or a non-retryable rejection ends the executor FAILED with the evidence in
+custom_info; and nothing it reports can be mistaken for a Gateway swap or an LP position.
+"""
+import asyncio
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("hummingbot")
+pytest.importorskip("aomi")
+
+from aomi.pipeline.errors import PipelineError  # noqa: E402
+from aomi.pipeline.models import Build, CommitOutcome  # noqa: E402
+from hummingbot.strategy_v2.models.base import RunnableStatus  # noqa: E402
+from hummingbot.strategy_v2.models.executors import CloseType  # noqa: E402
+
+from config import AomiSettings  # noqa: E402
+from models.onchain_executor import OnchainExecutorConfig  # noqa: E402
+from services.onchain_executor import OnchainExecutor, OnchainExecutorInfo, Phase  # noqa: E402
+from utils.executor_log_capture import ExecutorLogCapture, current_executor_id  # noqa: E402
+
+WALLET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+DIGEST = "0x" + "ab" * 32
+TX_HASH = "0x" + "cd" * 32
+A_CALL = {"to": WALLET, "value": "0", "data": {"signature": "", "args": [], "raw": ""}, "description": "self"}
+
+STAGED = {
+    "version": 1,
+    "status": "staged",
+    "digest": DIGEST,
+    "actions": [
+        {"chain_id": 8453, "from": WALLET, "to": WALLET, "value": "0", "label": "self-transfer",
+         "kind": "transfer", "protocol": None, "pending_tx_id": 1},
+    ],
+}
+PASSED_SIMULATION = {
+    "status": "passed",
+    "balanceChanges": [{"account": WALLET, "asset": "native", "amount": "-21000000", "direction": "out",
+                        "symbol": "ETH", "decimals": 18, "chainId": 8453}],
+    "gas": {"units": "21000", "priceWei": "1000000000", "nativeCost": "0.000021"},
+    "warnings": ["dust"],
+    "fees": [],
+    "guards": [],
+    "logs": [],
+}
+SIMULATED = {**STAGED, "status": "simulated", "simulation": PASSED_SIMULATION}
+REVERTED = {**STAGED, "status": "simulated", "simulation": {**PASSED_SIMULATION, "status": "reverted",
+                                                            "warnings": ["execution reverted"]}}
+UNPRICED = {**STAGED, "status": "simulated", "simulation": {**PASSED_SIMULATION, "gas": None}}
+
+CONFIRMED = {"status": "committed", "digest": DIGEST, "result": {"status": "confirmed", "tx_hashes": [TX_HASH]}}
+PENDING = {"status": "committed", "digest": DIGEST, "result": {"status": "pending_approval", "tx_ids": [7]}}
+AA_SIGN = {"status": "committed", "digest": DIGEST, "result": {"status": "aa_sign_request"},
+           "requests": [{"kind": "aa_sign", "tx_id": 7}]}
+
+
+class FakePipelineClient:
+    """A scripted /v1/pipeline. ``errors[method]`` is a queue of exceptions raised before the reply."""
+
+    def __init__(self, *, staged=STAGED, simulated=SIMULATED, built=None, outcome=CONFIRMED, errors=None):
+        self.staged = staged
+        self.simulated = simulated
+        self.built = built if built is not None else simulated
+        self.outcome = outcome
+        self.errors = {k: list(v) for k, v in (errors or {}).items()}
+        self.calls = []
+        self.commit_keys = []
+        self.closed = False
+
+    def _maybe_raise(self, method):
+        queue = self.errors.get(method)
+        if queue:
+            raise queue.pop(0)
+
+    async def stage_evm(self, actions, *, app=None, skills=None):
+        self.calls.append(("stage_evm", {"actions": actions, "app": app, "skills": skills}))
+        self._maybe_raise("stage_evm")
+        return Build.from_json(dict(self.staged), "evm")
+
+    async def build(self, chain, *, app=None, skills=None, operation=None, arguments=None, operations=None):
+        self.calls.append(("build", {"chain": chain, "app": app, "skills": skills, "operation": operation,
+                                     "arguments": arguments}))
+        self._maybe_raise("build")
+        return Build.from_json(dict(self.built), chain)
+
+    async def simulate(self, build):
+        self.calls.append(("simulate", {"digest": build.digest}))
+        self._maybe_raise("simulate")
+        return Build.from_json(dict(self.simulated), build.chain)
+
+    async def commit(self, build, *, idempotency_key=None):
+        self.calls.append(("commit", {"digest": build.digest}))
+        self.commit_keys.append(idempotency_key or build.digest)
+        assert build.is_simulated, "commit() needs a simulated Build"
+        self._maybe_raise("commit")
+        return CommitOutcome.from_response(dict(self.outcome))
+
+    async def close(self):
+        self.closed = True
+
+    def methods_called(self):
+        return [name for name, _ in self.calls]
+
+
+def _strategy(market_data_service=None):
+    return SimpleNamespace(connectors={}, current_timestamp=1000.0, _market_data_service=market_data_service)
+
+
+def _config(**overrides):
+    fields = {"chain_id": 8453, "mode": "calls", "calls": [A_CALL]}
+    fields.update(overrides)
+    return OnchainExecutorConfig(**fields)
+
+
+def _executor(client, *, config=None, strategy=None, max_retries=10, update_interval=0.01):
+    return OnchainExecutor(
+        strategy=strategy or _strategy(),
+        config=config or _config(),
+        update_interval=update_interval,
+        max_retries=max_retries,
+        client_factory=lambda: client,
+    )
+
+
+async def _run(executor, max_ticks=30):
+    """Drive the executor the way core's control loop does, until it terminates."""
+    await executor.on_start()
+    ticks = 0
+    while not executor.is_closed and ticks < max_ticks:
+        await executor.control_task()
+        executor.evaluate_max_retries()
+        ticks += 1
+    return ticks
+
+
+def _retryable():
+    return PipelineError(503, "upstream_unavailable", "try again", request_id="req-503")
+
+
+def _transport():
+    return PipelineError(0, "transport", "ClientConnectorError: reset")
+
+
+# ---------------------------------------------------------------------------- happy paths
+
+
+@pytest.mark.asyncio
+async def test_calls_mode_stages_simulates_and_commits():
+    client = FakePipelineClient()
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.methods_called() == ["stage_evm", "simulate", "commit"]
+    staged = client.calls[0][1]
+    assert staged["actions"][0]["chain_id"] == 8453
+    assert staged["app"] == "default"
+    info = executor.get_custom_info()
+    assert info["phase"] == "done"
+    assert info["committed"] is True
+    assert info["outcome_kind"] == "confirmed"
+    assert info["tx_hashes"] == [TX_HASH]
+    assert info["digest"] == DIGEST
+    assert info["wallet_address"] == WALLET
+    assert info["action_count"] == 1
+    assert info["actions"][0]["to"] == WALLET
+    assert info["simulation_passed"] is True
+    assert info["simulation_warnings"] == ["dust"]
+    assert info["balance_changes"][0]["symbol"] == "ETH"
+    assert info["gas_units"] == "21000"
+    assert info["error"] is None
+    assert info["reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_operation_mode_builds_and_skips_the_simulate_call():
+    """A build comes back already simulated, so the executor goes straight to the risk check."""
+    client = FakePipelineClient()
+    config = _config(mode="operation", calls=None, app="erc20", operation="transfer", arguments={"amount": "1"},
+                     skills=["gas"])
+    executor = _executor(client, config=config)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.methods_called() == ["build", "commit"]
+    built = client.calls[0][1]
+    assert built["chain"] == "evm"
+    assert built["app"] == "erc20"
+    assert built["skills"] == ["gas"]
+    assert built["operation"] == "/v1/pipeline/apps/erc20/operations/transfer"
+    assert built["arguments"] == {"amount": "1"}
+
+
+@pytest.mark.asyncio
+async def test_a_build_that_is_not_simulated_yet_gets_simulated():
+    client = FakePipelineClient(built=STAGED)
+    executor = _executor(client, config=_config(mode="operation", calls=None, operation="transfer"))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.methods_called() == ["build", "simulate", "commit"]
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_completes_without_committing():
+    client = FakePipelineClient()
+    executor = _executor(client, config=_config(commit=False))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.methods_called() == ["stage_evm", "simulate"]
+    info = executor.get_custom_info()
+    assert info["committed"] is False
+    assert info["simulation_passed"] is True
+    assert info["tx_hashes"] == []
+
+
+@pytest.mark.asyncio
+async def test_one_phase_per_tick():
+    client = FakePipelineClient()
+    executor = _executor(client)
+    await executor.on_start()
+
+    seen = [executor.get_custom_info()["phase"]]
+    while not executor.is_closed:
+        await executor.control_task()
+        seen.append(executor.get_custom_info()["phase"])
+
+    assert seen == ["staging", "simulating", "risk_check", "committing", "confirming", "done"]
+
+
+# ---------------------------------------------------------------------------- failures
+
+
+@pytest.mark.asyncio
+async def test_a_failed_simulation_ends_failed_with_the_evidence():
+    client = FakePipelineClient(simulated=REVERTED)
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    assert "commit" not in client.methods_called()
+    info = executor.get_custom_info()
+    assert info["reason"] == "simulation_failed"
+    assert info["simulation_passed"] is False
+    assert info["error"]["phase"] == "risk_check"
+    assert info["error"]["evidence"]["status"] == "reverted"
+    assert "execution reverted" in info["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_stale_build_on_commit_is_not_retried():
+    stale = PipelineError(409, "stale_build", "rebuild differs", request_id="req-409", backend_code="digest_mismatch")
+    client = FakePipelineClient(errors={"commit": [stale]})
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    assert client.methods_called().count("commit") == 1
+    error = executor.get_custom_info()["error"]
+    assert error["reason"] == "committing_rejected"
+    assert error["status"] == 409
+    assert error["code"] == "stale_build"
+    assert error["backend_code"] == "digest_mismatch"
+    assert error["request_id"] == "req-409"
+    assert error["phase"] == "committing"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_stage_is_not_retried():
+    client = FakePipelineClient(errors={"stage_evm": [PipelineError(422, "invalid_action", "bad calldata")]})
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    assert client.methods_called() == ["stage_evm"]
+    assert executor.get_custom_info()["reason"] == "staging_rejected"
+
+
+@pytest.mark.asyncio
+async def test_retryable_errors_count_against_max_retries():
+    client = FakePipelineClient(errors={"simulate": [_retryable() for _ in range(10)]})
+    executor = _executor(client, max_retries=2)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    assert executor._current_retries == 3  # core stops once retries exceed the maximum
+    assert client.methods_called() == ["stage_evm", "simulate", "simulate", "simulate"]
+
+
+@pytest.mark.asyncio
+async def test_a_retryable_error_keeps_the_phase():
+    client = FakePipelineClient(errors={"simulate": [_retryable()]})
+    executor = _executor(client)
+    await executor.on_start()
+    await executor.control_task()  # stage
+    await executor.control_task()  # simulate -> 503
+
+    assert executor.get_custom_info()["phase"] == "simulating"
+    assert executor._current_retries == 1
+    assert not executor.is_closed
+
+    while not executor.is_closed:
+        await executor.control_task()
+    assert executor.close_type == CloseType.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_a_commit_lost_in_transport_is_replayed_under_the_same_key():
+    """The idempotency key is the digest, so the replay returns the ledger entry, not a second tx."""
+    client = FakePipelineClient(errors={"commit": [_transport()]})
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.commit_keys == [DIGEST, DIGEST]
+    assert executor._commit_sent is True
+    assert executor.get_custom_info()["tx_hashes"] == [TX_HASH]
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_exception_fails_closed():
+    class Boom(FakePipelineClient):
+        async def simulate(self, build):
+            raise KeyError("simulation")
+
+    executor = _executor(Boom())
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    error = executor.get_custom_info()["error"]
+    assert error["reason"] == "unexpected"
+    assert "KeyError" in error["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome, kind", [(PENDING, "pending_approval"), (AA_SIGN, "aa_sign_request")])
+async def test_a_commit_that_needs_a_wallet_signature_fails_as_awaiting_wallet(outcome, kind):
+    client = FakePipelineClient(outcome=outcome)
+    executor = _executor(client)
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    info = executor.get_custom_info()
+    assert info["reason"] == "awaiting_wallet"
+    assert info["outcome_kind"] == kind
+    assert info["committed"] is False
+    assert info["error"]["outcome_kind"] == kind
+    if kind == "pending_approval":
+        assert info["tx_ids"] == [7]
+    else:
+        assert info["commit_requests"] == [{"kind": "aa_sign", "tx_id": 7}]
+
+
+@pytest.mark.asyncio
+async def test_a_slow_pipeline_times_out_before_the_commit():
+    client = FakePipelineClient(errors={"simulate": [_retryable() for _ in range(10)]})
+    strategy = _strategy()
+    executor = _executor(client, config=_config(timeout_sec=5), strategy=strategy)
+    await executor.on_start()
+    await executor.control_task()  # stage
+    strategy.current_timestamp = 1006.0
+    await executor.control_task()
+
+    assert executor.close_type == CloseType.FAILED
+    assert executor.get_custom_info()["reason"] == "timeout"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_does_not_apply_once_the_commit_is_sent():
+    client = FakePipelineClient(errors={"commit": [_transport()]})
+    strategy = _strategy()
+    executor = _executor(client, config=_config(timeout_sec=5), strategy=strategy)
+    await executor.on_start()
+    for _ in range(4):  # stage, simulate, risk check, commit (lost)
+        await executor.control_task()
+    assert executor._commit_sent is True
+    strategy.current_timestamp = 2000.0
+
+    while not executor.is_closed:
+        await executor.control_task()
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.commit_keys == [DIGEST, DIGEST]
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_aomi_fails_the_executor_instead_of_raising(monkeypatch):
+    import services.onchain_executor as module
+
+    monkeypatch.setattr(module.settings, "aomi", AomiSettings(token="", token_file=""))
+    executor = OnchainExecutor(strategy=_strategy(), config=_config())
+
+    await executor.on_start()
+
+    assert executor.is_closed
+    assert executor.close_type == CloseType.FAILED
+    error = executor.get_custom_info()["error"]
+    assert error["reason"] == "startup"
+    assert "AOMI_TOKEN" in error["message"]
+
+
+# ---------------------------------------------------------------------------- early stop
+
+
+@pytest.mark.asyncio
+async def test_early_stop_before_the_commit_stops_the_executor():
+    client = FakePipelineClient()
+    executor = _executor(client)
+    await executor.on_start()
+    await executor.control_task()  # stage
+
+    executor.early_stop()
+
+    assert executor.is_closed
+    assert executor.close_type == CloseType.EARLY_STOP
+    await executor.control_task()
+    assert client.methods_called() == ["stage_evm"]
+
+
+@pytest.mark.asyncio
+async def test_early_stop_after_the_commit_cannot_cancel_it():
+    client = FakePipelineClient()
+    executor = _executor(client)
+    await executor.on_start()
+    for _ in range(4):  # stage, simulate, risk check, commit
+        await executor.control_task()
+    assert executor._commit_sent is True
+
+    executor.early_stop()
+
+    assert not executor.is_closed
+    assert executor.close_type is None
+    while not executor.is_closed:
+        await executor.control_task()
+    assert executor.close_type == CloseType.COMPLETED
+
+
+# ---------------------------------------------------------------------------- fees and gas budget
+
+
+@pytest.mark.asyncio
+async def test_gas_is_priced_when_the_api_has_a_rate():
+    market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
+    executor = _executor(FakePipelineClient(), strategy=_strategy(market_data))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+    assert executor.get_cum_fees_quote() == Decimal("0.000021") * Decimal("3000")
+    assert executor.get_custom_info()["fees_quote_source"] == "priced"
+
+
+@pytest.mark.asyncio
+async def test_a_gas_budget_refuses_an_expensive_commit():
+    market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
+    client = FakePipelineClient()
+    executor = _executor(client, config=_config(max_gas_quote=Decimal("0.01")), strategy=_strategy(market_data))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.FAILED
+    assert "commit" not in client.methods_called()
+    assert executor.get_custom_info()["reason"] == "gas_over_budget"
+
+
+@pytest.mark.asyncio
+async def test_a_gas_budget_passes_a_cheap_commit():
+    market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
+    executor = _executor(FakePipelineClient(), config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market_data))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_unpriced_gas_reports_zero_fees_and_says_so():
+    executor = _executor(FakePipelineClient(simulated=UNPRICED), config=_config(max_gas_quote=Decimal("0.01")))
+
+    await _run(executor)
+
+    assert executor.close_type == CloseType.COMPLETED  # the budget cannot be enforced without a price
+    assert executor.get_cum_fees_quote() == Decimal("0")
+    info = executor.get_custom_info()
+    assert info["fees_quote_source"] == "unpriced"
+    assert info["gas_native_cost"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_market_data_service_means_unpriced():
+    executor = _executor(FakePipelineClient())
+
+    await _run(executor)
+
+    assert executor.get_cum_fees_quote() == Decimal("0")
+    assert executor.get_custom_info()["fees_quote_source"] == "unpriced"
+
+
+# ---------------------------------------------------------------------------- reporting
+
+
+@pytest.mark.asyncio
+async def test_executor_info_carries_the_onchain_config():
+    executor = _executor(FakePipelineClient())
+
+    await _run(executor)
+    info = executor.executor_info
+
+    assert isinstance(info, OnchainExecutorInfo)
+    assert info.side is None
+    assert info.type == "onchain_executor"
+    assert info.close_type == CloseType.COMPLETED
+    assert info.net_pnl_quote == Decimal("0")
+    assert info.filled_amount_quote == Decimal("0")
+    dumped = info.model_dump()
+    assert dumped["config"]["chain_id"] == 8453
+    assert dumped["custom_info"]["tx_hashes"] == [TX_HASH]
+    assert info.connector_name == "base"
+    assert info.trading_pair == "ETH-ETH"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", [CONFIRMED, PENDING])
+async def test_custom_info_never_looks_like_a_swap_or_an_lp_position(outcome):
+    """ExecutorService records custom_info['transaction_hash'] as a Gateway swap and flags
+    custom_info['position_address'] as an orphaned position."""
+    executor = _executor(FakePipelineClient(outcome=outcome))
+    snapshots = [executor.get_custom_info()]
+    await executor.on_start()
+    while not executor.is_closed:
+        await executor.control_task()
+        snapshots.append(executor.get_custom_info())
+
+    for info in snapshots:
+        assert "transaction_hash" not in info
+        assert "position_address" not in info
+
+
+@pytest.mark.asyncio
+async def test_custom_info_is_json_serializable_at_every_phase():
+    import json
+
+    executor = _executor(FakePipelineClient(simulated=REVERTED))
+    json.dumps(executor.get_custom_info())
+    await executor.on_start()
+    while not executor.is_closed:
+        await executor.control_task()
+        json.dumps(executor.get_custom_info())
+
+
+@pytest.mark.asyncio
+async def test_a_failure_is_captured_in_the_executor_log():
+    capture = ExecutorLogCapture()
+    capture.install()
+    executor = _executor(FakePipelineClient(simulated=REVERTED))
+    token = current_executor_id.set(executor.config.id)
+    try:
+        await _run(executor)
+    finally:
+        current_executor_id.reset(token)
+        capture.uninstall()
+
+    assert executor.close_type == CloseType.FAILED
+    assert capture.get_error_count(executor.config.id) >= 1
+    assert "simulation_failed" in capture.get_last_error(executor.config.id)
+
+
+@pytest.mark.asyncio
+async def test_start_runs_the_whole_lifecycle_on_the_control_loop():
+    """The real entry point: start() spawns the control loop, and on_stop closes the client."""
+    client = FakePipelineClient()
+    executor = _executor(client, update_interval=0.01)
+
+    executor.start()
+    assert executor.status == RunnableStatus.RUNNING
+    await asyncio.wait_for(executor.terminated.wait(), 5)
+    await asyncio.sleep(0.05)  # on_stop runs after the loop exits and schedules close()
+
+    assert executor.status == RunnableStatus.TERMINATED
+    assert executor.close_type == CloseType.COMPLETED
+    assert executor.close_timestamp == 1000.0
+    assert executor.get_custom_info()["phase"] == Phase.DONE.value
+    assert client.closed is True

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -335,6 +335,18 @@ async def test_a_commit_lost_in_transport_is_replayed_under_the_same_key():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["stage_evm", "simulate", "commit"])
+async def test_account_contention_retries_the_same_phase_and_commits_once(phase):
+    client = FakePipelineClient(errors={phase: [PipelineError(409, "operation_in_flight", "busy")]})
+    executor = _executor(client)
+    await _run(executor)
+    assert executor.close_type == CloseType.COMPLETED
+    assert client.methods_called().count(phase) == 2
+    assert set(client.commit_keys) == {DIGEST}
+    assert executor.get_custom_info()["tx_hashes"] == [TX_HASH]
+
+
+@pytest.mark.asyncio
 async def test_an_unexpected_exception_fails_closed():
     class Boom(FakePipelineClient):
         async def simulate(self, build):

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -9,6 +9,7 @@ custom_info; and nothing it reports can be mistaken for a Gateway swap or an LP 
 """
 
 import asyncio
+import copy
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -109,6 +110,11 @@ class FakePipelineClient:
         self._maybe_raise("stage_evm")
         return Build.from_json(dict(self.staged), "evm")
 
+    async def stage_svm(self, *, instructions, app=None, skills=None):
+        self.calls.append(("stage_svm", {"instructions": instructions, "app": app, "skills": skills}))
+        self._maybe_raise("stage_svm")
+        return Build.from_json(dict(self.staged), "svm")
+
     async def build(self, chain, *, app=None, skills=None, operation=None, arguments=None, operations=None):
         self.calls.append(
             ("build", {"chain": chain, "app": app, "skills": skills, "operation": operation, "arguments": arguments})
@@ -175,6 +181,177 @@ def _transport():
 
 
 # ---------------------------------------------------------------------------- happy paths
+
+
+def _svm_fee_build():
+    return {
+        "status": "simulated", "digest": DIGEST,
+        "actions": [{"lane": "instruction", "instruction": {
+            "payer": "solana-wallet", "cluster": "mainnet-beta", "program_id": "program",
+            "accounts": [{"pubkey": "account", "is_signer": False, "is_writable": True}],
+            "data_base64": "AA==", "assembly": {"version": "v0"},
+        }}],
+        "simulation": {"status": "passed", "fees": [{
+            "account": "solana-wallet", "asset": "native", "amount": "5000",
+            "decimals": 9, "cluster": "mainnet-beta", "kind": "network",
+        }], "guards": [{"name": "svm_network_fees", "status": "passed"}]},
+    }
+
+
+def _svm_fee_config(limit=5000):
+    return OnchainExecutorConfig(
+        chain="svm", chain_id=1, mode="instructions", commit=True,
+        instructions=[{"instructions": [{"program_id": "program", "data_base64": "AA==", "accounts": []}]}],
+        max_svm_network_fee_lamports=limit,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit,reason", [(4999, "network_fee_over_budget"), (5000, None), (0, "network_fee_over_budget")])
+async def test_svm_fee_ceiling_is_enforced_before_commit_without_a_quote_price(limit, reason):
+    build = _svm_fee_build()
+    client = FakePipelineClient(staged=build)
+    executor = _executor(client, config=_svm_fee_config(limit))
+    await _run(executor)
+    info = executor.get_custom_info()
+    assert info["reason"] == reason
+    assert ("commit" in client.methods_called()) == (reason is None)
+    assert info["estimated_svm_network_fee_lamports"] == "5000"
+    assert info["estimated_gas_quote"] is None
+    assert info["simulation_fees"] == build["simulation"]["fees"]
+    assert executor.get_cum_fees_quote() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", [
+    "missing_guard", "failed_guard", "duplicate_guard", "missing_fee", "wrong_cluster",
+    "wrong_payer", "action_cluster", "action_payer", "negative", "decimal", "nan",
+    "integer", "boolean", "wrong_decimals", "wrong_asset", "wrong_kind", "overflow",
+])
+async def test_incomplete_or_mismatched_svm_fee_evidence_never_commits(mutation):
+    build = _svm_fee_build()
+    sim = build["simulation"]
+    fee = sim["fees"][0]
+    if mutation == "missing_guard":
+        sim["guards"] = []
+    elif mutation == "failed_guard":
+        sim["guards"][0]["status"] = "failed"
+    elif mutation == "duplicate_guard":
+        sim["guards"] *= 2
+    elif mutation == "missing_fee":
+        sim["fees"] = []
+    elif mutation == "wrong_cluster":
+        fee["cluster"] = "devnet"
+    elif mutation == "wrong_payer":
+        fee["account"] = "other"
+    elif mutation == "action_cluster":
+        build["actions"][0]["instruction"]["cluster"] = "devnet"
+    elif mutation == "action_payer":
+        other = copy.deepcopy(build["actions"][0])
+        other["instruction"]["payer"] = "other"
+        build["actions"].append(other)
+    elif mutation == "wrong_decimals":
+        fee["decimals"] = 18
+    elif mutation == "wrong_asset":
+        fee["asset"] = "token"
+    elif mutation == "wrong_kind":
+        fee["kind"] = "protocol"
+    else:
+        fee["amount"] = {
+            "negative": "-1", "decimal": "0.5", "nan": "NaN", "integer": 5000,
+            "boolean": True, "overflow": str(2**64),
+        }[mutation]
+    client = FakePipelineClient(staged=build)
+    executor = _executor(client, config=_svm_fee_config())
+    await _run(executor)
+    assert executor.get_custom_info()["reason"] == "network_fee_unavailable"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+async def test_svm_fee_ceiling_counts_all_network_fees():
+    build = _svm_fee_build()
+    build["simulation"]["fees"] *= 2
+    client = FakePipelineClient(staged=build)
+    executor = _executor(client, config=_svm_fee_config(9999))
+    await _run(executor)
+    assert executor.get_custom_info()["estimated_svm_network_fee_lamports"] == "10000"
+    assert executor.get_custom_info()["reason"] == "network_fee_over_budget"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("payer", "other"), ("cluster", "devnet"), ("program_id", "different-program"),
+    ("data_base64", "AQ=="), ("accounts", []),
+    ("accounts", [{"pubkey": "account", "is_signer": True, "is_writable": True}]),
+    ("assembly", {"version": "v0", "priority_microlamports": 99999}),
+    ("assembly", {"version": "v0", "address_lookup_tables": ["another-table"]}),
+    ("new_execution_field", "unknown-extension"),
+])
+async def test_reviewed_plan_refuses_changed_authority_or_instruction_before_commit(field, value):
+    preview = _executor(FakePipelineClient(), config=_svm_fee_config())
+    preview._build = Build.from_json(_svm_fee_build(), "svm")
+    reviewed = preview.get_custom_info()["svm_plan_hash"]
+    assert reviewed is not None
+    changed = _svm_fee_build()
+    changed["actions"][0]["instruction"][field] = value
+    config = _svm_fee_config()
+    config.reviewed_svm_plan_hash = reviewed
+    client = FakePipelineClient(staged=changed)
+    executor = _executor(client, config=config)
+    await _run(executor)
+    assert executor.get_custom_info()["reason"] == "reviewed_plan_changed"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+async def test_reviewed_instruction_plan_survives_only_nonexecution_restaging_metadata():
+    original = _svm_fee_build()
+    original["actions"][0]["instruction"]["pending_ix_id"] = 1
+    preview = _executor(FakePipelineClient(), config=_svm_fee_config())
+    preview._build = Build.from_json(original, "svm")
+    config = _svm_fee_config()
+    config.reviewed_svm_plan_hash = preview.get_custom_info()["svm_plan_hash"]
+    restaged = copy.deepcopy(original)
+    restaged.update(digest="new-digest", expiresAt=123456)
+    restaged["actions"][0]["id"] = 30
+    restaged["actions"][0]["instruction"].update(pending_ix_id=30, current_lifecycle="queued", description="New label")
+    client = FakePipelineClient(staged=restaged)
+    executor = _executor(client, config=config)
+    await _run(executor)
+    assert executor.get_custom_info()["reason"] is None
+    assert "commit" in client.methods_called()
+
+
+def test_svm_evidence_reports_actual_network_even_when_config_label_differs():
+    config = _svm_fee_config()
+    config.cluster = "devnet"
+    executor = _executor(FakePipelineClient(), config=config)
+    executor._build = Build.from_json(_svm_fee_build(), "svm")
+    info = executor.get_custom_info()
+    assert info["cluster"] == "mainnet-beta"
+    assert info["requested_cluster"] == "devnet"
+    assert info["estimated_svm_network_fee_lamports"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit,simulation,methods,close_type", [
+    (True, SIMULATED, ["stage_svm", "simulate", "commit"], CloseType.COMPLETED),
+    (False, SIMULATED, ["stage_svm", "simulate"], CloseType.COMPLETED),
+    (True, REVERTED, ["stage_svm", "simulate"], CloseType.FAILED),
+])
+async def test_svm_instructions_use_shared_lifecycle_and_refuse_failed_simulation(commit, simulation, methods, close_type):
+    batches = [{"description": "deposit", "address_lookup_tables": ["lookup"],
+                "instructions": [{"program_id": "program", "accounts": [], "data_base64": "AA=="}]}]
+    client = FakePipelineClient(simulated=simulation)
+    executor = _executor(client, config=OnchainExecutorConfig(
+        chain="svm", chain_id=1, mode="instructions", instructions=batches, commit=commit,
+    ))
+    await _run(executor)
+    assert client.methods_called() == methods
+    assert client.calls[0][1]["instructions"] == batches
+    assert executor.close_type == close_type
 
 
 @pytest.mark.asyncio
@@ -705,3 +882,26 @@ async def test_lending_plan_checks_actual_calldata_before_commit(tamper):
     else:
         assert "commit" in client.methods_called()
         assert executor.close_type == CloseType.COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit,complete,refused", [("2000000", True, False), ("1999999", True, True), ("2000000", False, True)])
+async def test_asset_budget_and_missing_evidence_refuse_before_wallet_handoff(limit, complete, refused):
+    build = _svm_fee_build()
+    build["simulation"]["balanceChanges"] = [
+        {"account": "solana-wallet", "asset": "USDC", "amount": "2000000", "direction": "out",
+         "cluster": "mainnet-beta", "step": 0},
+    ]
+    if complete:
+        build["simulation"]["guards"].append({"name": "svm_balance_changes", "status": "passed"})
+    config = _svm_fee_config()
+    from models.svm_policy import SvmSpendingPolicy
+    config.svm_spending_policy = SvmSpendingPolicy(
+        wallet="solana-wallet", market="account", protocol_program="program", allowed_programs=["program"],
+        max_debits_raw={"native": "10000", "USDC": limit},
+    )
+    client = FakePipelineClient(staged=build)
+    executor = _executor(client, config=config)
+    await _run(executor)
+    assert ("commit" not in client.methods_called()) == refused
+    assert executor.get_custom_info()["reason"] == ("spending_policy_refused" if refused else None)

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -499,7 +499,8 @@ async def test_unpriced_gas_reports_zero_fees_and_says_so():
 
     await _run(executor)
 
-    assert executor.close_type == CloseType.COMPLETED  # the budget cannot be enforced without a price
+    assert executor.close_type == CloseType.FAILED
+    assert executor.get_custom_info()["reason"] == "gas_unpriced"
     assert executor.get_cum_fees_quote() == Decimal("0")
     info = executor.get_custom_info()
     assert info["fees_quote_source"] == "unpriced"
@@ -601,3 +602,41 @@ async def test_start_runs_the_whole_lifecycle_on_the_control_loop():
     assert executor.close_timestamp == 1000.0
     assert executor.get_custom_info()["phase"] == Phase.DONE.value
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_default_pair_does_not_change_gas_budget_currency():
+    from hummingbot.core.rate_oracle.utils import find_rate
+
+    market = SimpleNamespace(get_rate=lambda base, quote: find_rate({"ETH-USDT": Decimal("3000")}, f"{base}-{quote}"))
+    client = FakePipelineClient()
+    executor = _executor(client, config=_config(max_gas_quote=Decimal("0.01")), strategy=_strategy(market))
+    await _run(executor)
+    assert executor.get_cum_fees_quote() == Decimal("0.063")
+    assert executor.get_custom_info()["reason"] == "gas_over_budget"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rate", [None, Decimal("NaN"), Decimal("Infinity"), Decimal("-1"), Decimal("0")])
+async def test_unavailable_or_invalid_price_blocks_budgeted_commit(rate):
+    client = FakePipelineClient()
+    market = SimpleNamespace(get_rate=lambda base, quote: rate)
+    executor = _executor(client, config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market))
+    await _run(executor)
+    assert executor.get_custom_info()["reason"] == "gas_unpriced"
+    assert "commit" not in client.methods_called()
+
+
+@pytest.mark.asyncio
+async def test_svm_gas_uses_sol_usdt():
+    pairs = []
+
+    def rate(base, quote):
+        pairs.append((base, quote))
+        return Decimal("150")
+    client = FakePipelineClient()
+    config = _config(chain="svm", chain_id=1, mode="operation", calls=None, operation="jupiter_swap", max_gas_quote=1)
+    executor = _executor(client, config=config, strategy=_strategy(SimpleNamespace(get_rate=rate)))
+    await _run(executor)
+    assert pairs and set(pairs) == {("SOL", "USDT")}

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -486,7 +486,9 @@ async def test_a_gas_budget_refuses_an_expensive_commit():
 @pytest.mark.asyncio
 async def test_a_gas_budget_passes_a_cheap_commit():
     market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
-    executor = _executor(FakePipelineClient(), config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market_data))
+    executor = _executor(
+        FakePipelineClient(), config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market_data)
+    )
 
     await _run(executor)
 
@@ -640,3 +642,25 @@ async def test_svm_gas_uses_sol_usdt():
     executor = _executor(client, config=config, strategy=_strategy(SimpleNamespace(get_rate=rate)))
     await _run(executor)
     assert pairs and set(pairs) == {("SOL", "USDT")}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tamper", [False, True])
+async def test_lending_plan_checks_actual_calldata_before_commit(tamper):
+    from aomi.pipeline.lending import LendingPlan
+
+    plan = LendingPlan(8453, "0x" + "11" * 20, "0x" + "22" * 20, WALLET, 1000000, "supply")
+    actions = [dict(call, data=call["data"]["raw"], **{"from": WALLET}) for call in plan.calls()]
+    if tamper:
+        actions[0]["data"] = actions[0]["data"][:-64] + "f" * 64
+    staged = {**STAGED, "actions": actions}
+    simulated = {**SIMULATED, "actions": actions}
+    client = FakePipelineClient(staged=staged, simulated=simulated)
+    executor = _executor(client, config=_config(mode="lending", calls=None, lending=plan))
+    await _run(executor)
+    if tamper:
+        assert "commit" not in client.methods_called()
+        assert executor.get_custom_info()["reason"] == "lending_plan_changed"
+    else:
+        assert "commit" in client.methods_called()
+        assert executor.close_type == CloseType.COMPLETED

--- a/test/test_onchain_executor_runs_the_pipeline.py
+++ b/test/test_onchain_executor_runs_the_pipeline.py
@@ -7,6 +7,7 @@ the executor's own policy: one commit at most, replayed under the same idempoten
 failing simulation or a non-retryable rejection ends the executor FAILED with the evidence in
 custom_info; and nothing it reports can be mistaken for a Gateway swap or an LP position.
 """
+
 import asyncio
 from decimal import Decimal
 from types import SimpleNamespace
@@ -36,14 +37,31 @@ STAGED = {
     "status": "staged",
     "digest": DIGEST,
     "actions": [
-        {"chain_id": 8453, "from": WALLET, "to": WALLET, "value": "0", "label": "self-transfer",
-         "kind": "transfer", "protocol": None, "pending_tx_id": 1},
+        {
+            "chain_id": 8453,
+            "from": WALLET,
+            "to": WALLET,
+            "value": "0",
+            "label": "self-transfer",
+            "kind": "transfer",
+            "protocol": None,
+            "pending_tx_id": 1,
+        },
     ],
 }
 PASSED_SIMULATION = {
     "status": "passed",
-    "balanceChanges": [{"account": WALLET, "asset": "native", "amount": "-21000000", "direction": "out",
-                        "symbol": "ETH", "decimals": 18, "chainId": 8453}],
+    "balanceChanges": [
+        {
+            "account": WALLET,
+            "asset": "native",
+            "amount": "-21000000",
+            "direction": "out",
+            "symbol": "ETH",
+            "decimals": 18,
+            "chainId": 8453,
+        }
+    ],
     "gas": {"units": "21000", "priceWei": "1000000000", "nativeCost": "0.000021"},
     "warnings": ["dust"],
     "fees": [],
@@ -51,14 +69,21 @@ PASSED_SIMULATION = {
     "logs": [],
 }
 SIMULATED = {**STAGED, "status": "simulated", "simulation": PASSED_SIMULATION}
-REVERTED = {**STAGED, "status": "simulated", "simulation": {**PASSED_SIMULATION, "status": "reverted",
-                                                            "warnings": ["execution reverted"]}}
+REVERTED = {
+    **STAGED,
+    "status": "simulated",
+    "simulation": {**PASSED_SIMULATION, "status": "reverted", "warnings": ["execution reverted"]},
+}
 UNPRICED = {**STAGED, "status": "simulated", "simulation": {**PASSED_SIMULATION, "gas": None}}
 
 CONFIRMED = {"status": "committed", "digest": DIGEST, "result": {"status": "confirmed", "tx_hashes": [TX_HASH]}}
 PENDING = {"status": "committed", "digest": DIGEST, "result": {"status": "pending_approval", "tx_ids": [7]}}
-AA_SIGN = {"status": "committed", "digest": DIGEST, "result": {"status": "aa_sign_request"},
-           "requests": [{"kind": "aa_sign", "tx_id": 7}]}
+AA_SIGN = {
+    "status": "committed",
+    "digest": DIGEST,
+    "result": {"status": "aa_sign_request"},
+    "requests": [{"kind": "aa_sign", "tx_id": 7}],
+}
 
 
 class FakePipelineClient:
@@ -85,8 +110,9 @@ class FakePipelineClient:
         return Build.from_json(dict(self.staged), "evm")
 
     async def build(self, chain, *, app=None, skills=None, operation=None, arguments=None, operations=None):
-        self.calls.append(("build", {"chain": chain, "app": app, "skills": skills, "operation": operation,
-                                     "arguments": arguments}))
+        self.calls.append(
+            ("build", {"chain": chain, "app": app, "skills": skills, "operation": operation, "arguments": arguments})
+        )
         self._maybe_raise("build")
         return Build.from_json(dict(self.built), chain)
 
@@ -184,8 +210,7 @@ async def test_calls_mode_stages_simulates_and_commits():
 async def test_operation_mode_builds_and_skips_the_simulate_call():
     """A build comes back already simulated, so the executor goes straight to the risk check."""
     client = FakePipelineClient()
-    config = _config(mode="operation", calls=None, app="erc20", operation="transfer", arguments={"amount": "1"},
-                     skills=["gas"])
+    config = _config(mode="operation", calls=None, app="erc20", operation="transfer", arguments={"amount": "1"}, skills=["gas"])
     executor = _executor(client, config=config)
 
     await _run(executor)
@@ -471,15 +496,17 @@ async def test_early_stop_after_the_commit_cannot_cancel_it():
 
 
 @pytest.mark.asyncio
-async def test_gas_is_priced_when_the_api_has_a_rate():
+@pytest.mark.parametrize("commit", [False, True])
+async def test_gas_estimate_never_becomes_incurred_fees(commit):
     market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
-    executor = _executor(FakePipelineClient(), strategy=_strategy(market_data))
+    executor = _executor(FakePipelineClient(), config=_config(commit=commit), strategy=_strategy(market_data))
 
     await _run(executor)
 
     assert executor.close_type == CloseType.COMPLETED
-    assert executor.get_cum_fees_quote() == Decimal("0.000021") * Decimal("3000")
-    assert executor.get_custom_info()["fees_quote_source"] == "priced"
+    assert executor.get_cum_fees_quote() == Decimal("0")
+    assert Decimal(executor.get_custom_info()["estimated_gas_quote"]) == Decimal("0.063")
+    assert executor.get_custom_info()["fees_quote_source"] == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -498,9 +525,7 @@ async def test_a_gas_budget_refuses_an_expensive_commit():
 @pytest.mark.asyncio
 async def test_a_gas_budget_passes_a_cheap_commit():
     market_data = SimpleNamespace(get_rate=lambda base, quote: Decimal("3000"))
-    executor = _executor(
-        FakePipelineClient(), config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market_data)
-    )
+    executor = _executor(FakePipelineClient(), config=_config(max_gas_quote=Decimal("1")), strategy=_strategy(market_data))
 
     await _run(executor)
 
@@ -517,7 +542,8 @@ async def test_unpriced_gas_reports_zero_fees_and_says_so():
     assert executor.get_custom_info()["reason"] == "gas_unpriced"
     assert executor.get_cum_fees_quote() == Decimal("0")
     info = executor.get_custom_info()
-    assert info["fees_quote_source"] == "unpriced"
+    assert info["fees_quote_source"] == "unavailable"
+    assert info["estimated_gas_quote"] is None
     assert info["gas_native_cost"] is None
 
 
@@ -528,7 +554,8 @@ async def test_no_market_data_service_means_unpriced():
     await _run(executor)
 
     assert executor.get_cum_fees_quote() == Decimal("0")
-    assert executor.get_custom_info()["fees_quote_source"] == "unpriced"
+    assert executor.get_custom_info()["fees_quote_source"] == "unavailable"
+    assert executor.get_custom_info()["estimated_gas_quote"] is None
 
 
 # ---------------------------------------------------------------------------- reporting
@@ -626,7 +653,8 @@ async def test_default_pair_does_not_change_gas_budget_currency():
     client = FakePipelineClient()
     executor = _executor(client, config=_config(max_gas_quote=Decimal("0.01")), strategy=_strategy(market))
     await _run(executor)
-    assert executor.get_cum_fees_quote() == Decimal("0.063")
+    assert executor.get_cum_fees_quote() == Decimal("0")
+    assert Decimal(executor.get_custom_info()["estimated_gas_quote"]) == Decimal("0.063")
     assert executor.get_custom_info()["reason"] == "gas_over_budget"
     assert "commit" not in client.methods_called()
 
@@ -649,6 +677,7 @@ async def test_svm_gas_uses_sol_usdt():
     def rate(base, quote):
         pairs.append((base, quote))
         return Decimal("150")
+
     client = FakePipelineClient()
     config = _config(chain="svm", chain_id=1, mode="operation", calls=None, operation="jupiter_swap", max_gas_quote=1)
     executor = _executor(client, config=config, strategy=_strategy(SimpleNamespace(get_rate=rate)))

--- a/test/test_onchain_preparation.py
+++ b/test/test_onchain_preparation.py
@@ -63,3 +63,74 @@ async def test_missing_or_invalid_registered_identity_refuses_before_any_remote_
         await prepare_onchain(OnchainPreparationRequest(operation="venues"), c, application_id=application_id)
     c.svm_context.assert_not_awaited()
     c.invoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admission_contention_retries_each_unsigned_call_without_replaying_context(monkeypatch):
+    from aomi.pipeline.errors import PipelineError
+    pause = AsyncMock()
+    monkeypatch.setattr("services.onchain_preparation.asyncio.sleep", pause)
+    c = client()
+    busy = PipelineError(409, "operation_in_flight", "private detail")
+    c.svm_context.side_effect = [busy, {"address": "wallet", "cluster": "mainnet-beta"}]
+    c.invoke.side_effect = [busy, SimpleNamespace(result={"wallet": "wallet", "cluster": "mainnet-beta"}, build=None)]
+    await prepare_onchain(OnchainPreparationRequest(operation="position"), c, application_id=123)
+    assert c.svm_context.await_count == 2
+    assert c.invoke.await_count == 2
+    assert pause.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_persistent_contention_is_bounded_and_propagated(monkeypatch):
+    from aomi.pipeline.errors import PipelineError
+    from services.onchain_preparation import admitted_read
+    pause = AsyncMock()
+    monkeypatch.setattr("services.onchain_preparation.asyncio.sleep", pause)
+    busy = PipelineError(409, "operation_in_flight", "busy")
+    call = AsyncMock(side_effect=busy)
+    with pytest.raises(PipelineError) as caught:
+        await admitted_read(call)
+    assert caught.value is busy
+    assert call.await_count == 6
+    assert sum(args.args[0] for args in pause.await_args_list) == pytest.approx(4.65)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,code", [(0, "transport_error"), (408, "timeout"), (429, "rate_limit"),
+                                         (500, "backend_error"), (502, "backend_unavailable"),
+                                         (409, "build_changed"), (403, "operation_in_flight")])
+async def test_unknown_outcome_or_other_rejection_is_never_retried(status, code, monkeypatch):
+    from aomi.pipeline.errors import PipelineError
+    from services.onchain_preparation import admitted_read
+    pause = AsyncMock()
+    monkeypatch.setattr("services.onchain_preparation.asyncio.sleep", pause)
+    error = PipelineError(status, code, "private upstream detail")
+    call = AsyncMock(side_effect=error)
+    with pytest.raises(PipelineError) as caught:
+        await admitted_read(call)
+    assert caught.value is error
+    call.assert_awaited_once()
+    pause.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,code,expected", [(409, "operation_in_flight", 409),
+                                                  (502, "backend_unavailable", 502)])
+async def test_router_reports_busy_and_keeps_upstream_details_private(status, code, expected, monkeypatch, caplog):
+    from unittest.mock import MagicMock
+    from aomi.pipeline.errors import PipelineError
+    from fastapi import HTTPException
+    from routers.executors import onchain_preparation
+    from services.onchain_executor import OnchainExecutor
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=client())
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(OnchainExecutor, "_default_client", lambda: context)
+    failure = PipelineError(status, code, "PRIVATE_URL_AND_BODY", details={"secret": "PRIVATE_TOKEN"})
+    monkeypatch.setattr("services.onchain_preparation.prepare_onchain", AsyncMock(side_effect=failure))
+    with pytest.raises(HTTPException) as caught:
+        await onchain_preparation(OnchainPreparationRequest(operation="venues"))
+    assert caught.value.status_code == expected
+    assert "PRIVATE_" not in str(caught.value.detail) + caplog.text
+    if expected == 409:
+        assert "busy" in caught.value.detail

--- a/test/test_onchain_preparation.py
+++ b/test/test_onchain_preparation.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from models.onchain_preparation import OnchainPreparationRequest
+from services.onchain_preparation import prepare_onchain
+
+
+def client(payload=None, build=None, cluster="mainnet-beta"):
+    return SimpleNamespace(
+        svm_context=AsyncMock(return_value={"address": "wallet", "cluster": cluster, "rpc_endpoint": "private-rpc"}),
+        invoke=AsyncMock(return_value=SimpleNamespace(result=payload or {"wallet": "wallet", "cluster": cluster}, build=build)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_preparation_uses_connected_wallet_and_does_not_expose_rpc():
+    c = client()
+    request = OnchainPreparationRequest(operation="prepare", arguments={"venue": "kamino-earn", "market": "vault"})
+    result = await prepare_onchain(request, c, application_id=123)
+    c.invoke.assert_awaited_once_with(
+        "solana-defi", "solana_defi_prepare",
+        {"venue": "kamino-earn", "market": "vault", "wallet": "wallet"}, application_id=123,
+    )
+    assert result["wallet"] == "wallet"
+    assert "private-rpc" not in str(result)
+    assert "wallet" not in request.arguments
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("arguments,cluster", [({"wallet": "other"}, "mainnet-beta"), ({}, "devnet")])
+async def test_wallet_and_network_mismatch_refuse_before_app_invocation(arguments, cluster):
+    c = client(cluster=cluster)
+    with pytest.raises(ValueError):
+        await prepare_onchain(OnchainPreparationRequest(operation="prepare", arguments=arguments), c, application_id=123)
+    c.invoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload,build", [
+    ({"wallet": "other", "cluster": "mainnet-beta"}, None),
+    ({"wallet": "wallet", "cluster": "devnet"}, None), ({}, object()),
+])
+async def test_invalid_or_staged_app_response_is_not_an_approved_plan(payload, build):
+    with pytest.raises(ValueError):
+        await prepare_onchain(OnchainPreparationRequest(operation="prepare"), client(payload, build), application_id=123)
+
+
+def test_arbitrary_operations_and_fields_are_not_accepted():
+    with pytest.raises(ValidationError):
+        OnchainPreparationRequest(operation="commit")
+    with pytest.raises(ValidationError):
+        OnchainPreparationRequest(operation="prepare", url="http://other-service")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("application_id", [None, 0, -1, True, "123"])
+async def test_missing_or_invalid_registered_identity_refuses_before_any_remote_call(application_id):
+    c = client()
+    with pytest.raises(ValueError, match="application ID"):
+        await prepare_onchain(OnchainPreparationRequest(operation="venues"), c, application_id=application_id)
+    c.svm_context.assert_not_awaited()
+    c.invoke.assert_not_awaited()

--- a/test/test_optional_docker.py
+++ b/test/test_optional_docker.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from docker.errors import DockerException
+
+from services.bots_orchestrator import BotsOrchestrator
+from services.gateway_service import GatewayService
+
+
+def test_gateway_connects_on_use_and_retries_after_unavailable_docker():
+    client = Mock()
+    with patch("services.gateway_service.docker.from_env", side_effect=[DockerException("offline"), client]) as connect:
+        service = GatewayService()
+        connect.assert_not_called()
+        with pytest.raises(DockerException):
+            _ = service.client
+        assert service.client is client
+        assert service.client is client
+        assert connect.call_count == 2
+
+
+def test_bot_discovery_connects_on_use_and_retries_after_unavailable_docker():
+    client = Mock()
+    client.containers.list.return_value = []
+    with patch("services.bots_orchestrator.MQTTManager"), patch(
+        "services.bots_orchestrator.docker.from_env", side_effect=[DockerException("offline"), client]
+    ) as connect:
+        service = BotsOrchestrator("localhost", 1883, "", "", db_manager=Mock())
+        connect.assert_not_called()
+        with pytest.raises(DockerException):
+            service._sync_get_active_containers()
+        assert service._sync_get_active_containers() == []
+        assert service._sync_get_active_containers() == []
+        assert connect.call_count == 2

--- a/test/test_svm_spending_policy.py
+++ b/test/test_svm_spending_policy.py
@@ -1,0 +1,83 @@
+import copy
+
+import pytest
+from aomi.pipeline import Build
+from pydantic import ValidationError
+
+from models.svm_policy import SvmSpendingPolicy
+
+
+def policy(**overrides):
+    return SvmSpendingPolicy(**{
+        "wallet": "wallet", "market": "vault", "protocol_program": "protocol",
+        "allowed_programs": ["protocol"], "max_debits_raw": {"native": "10000", "USDC": "2000000"},
+        **overrides,
+    })
+
+
+def evidence():
+    return {"status": "simulated", "actions": [{"lane": "instruction", "instruction": {
+        "payer": "wallet", "cluster": "mainnet-beta", "program_id": "protocol", "accounts": [{"pubkey": "vault"}],
+    }}], "simulation": {"status": "passed", "fees": [{}], "guards": [
+        {"name": "svm_balance_changes", "status": "passed"},
+        {"name": "svm_network_fees", "status": "passed"},
+    ], "balanceChanges": [
+        {"account": "wallet", "asset": "native", "direction": "out", "amount": "5000", "cluster": "mainnet-beta", "step": 0},
+        {"account": "wallet", "asset": "USDC", "direction": "out", "amount": "2000000", "cluster": "mainnet-beta", "step": 0},
+    ]}}
+
+
+def verify(raw, limits=None):
+    return (limits or policy()).verify(Build.from_json(raw, "svm"), "mainnet-beta")
+
+
+def test_exact_inclusive_debit_ceiling():
+    assert verify(evidence()) == {"native": "5000", "USDC": "2000000"}
+    with pytest.raises(ValueError, match="exceeds"):
+        verify(evidence(), policy(max_debits_raw={"native": "10000", "USDC": "1999999"}))
+
+
+def test_credits_and_other_wallets_cannot_offset_our_debits():
+    raw = evidence()
+    credit = copy.deepcopy(raw["simulation"]["balanceChanges"][1])
+    credit.update(direction="in", amount="2000000")
+    raw["simulation"]["balanceChanges"].append(credit)
+    with pytest.raises(ValueError, match="exceeds"):
+        verify(raw, policy(max_debits_raw={"native": "10000", "USDC": "1"}))
+    raw["simulation"]["balanceChanges"][1]["account"] = "another-wallet"
+    assert verify(raw)["USDC"] == "0"
+
+
+def test_multiple_account_debits_are_summed():
+    raw = evidence()
+    raw["simulation"]["balanceChanges"].append(copy.deepcopy(raw["simulation"]["balanceChanges"][1]))
+    with pytest.raises(ValueError, match="exceeds"):
+        verify(raw)
+
+
+@pytest.mark.parametrize("mutation", [
+    lambda r: r["simulation"].update(guards=[]),
+    lambda r: r["simulation"]["guards"].append({"name": "svm_balance_changes", "status": "passed"}),
+    lambda r: r["simulation"]["guards"][0].update(status="failed"),
+    lambda r: r["simulation"]["fees"].append({}),
+    lambda r: r["simulation"]["guards"][1].update(status="failed"),
+    lambda r: r["simulation"]["balanceChanges"][0].update(account=None),
+    lambda r: r["simulation"]["balanceChanges"][0].update(cluster="devnet"),
+    lambda r: r["simulation"]["balanceChanges"][0].update(step=True),
+    lambda r: r["simulation"]["balanceChanges"][0].update(amount="-1"),
+    lambda r: r["simulation"]["balanceChanges"][1].update(asset="unapproved-asset"),
+    lambda r: r["actions"][0]["instruction"].update(program_id="other-protocol"),
+    lambda r: r["actions"][0]["instruction"].update(accounts=[{"pubkey": "other-vault"}]),
+    lambda r: r["actions"][0]["instruction"].update(payer="another-wallet"),
+])
+def test_incomplete_evidence_or_changed_venue_refuses(mutation):
+    raw = evidence()
+    mutation(raw)
+    with pytest.raises(ValueError):
+        verify(raw)
+
+
+@pytest.mark.parametrize("limits", [{"USDC": "1"}, {"native": "-1"}, {"native": 1}, {"native": "18446744073709551616"}])
+def test_invalid_raw_limits_refuse_at_configuration(limits):
+    with pytest.raises(ValidationError):
+        policy(max_debits_raw=limits)

--- a/test/test_svm_spending_policy.py
+++ b/test/test_svm_spending_policy.py
@@ -81,3 +81,22 @@ def test_incomplete_evidence_or_changed_venue_refuses(mutation):
 def test_invalid_raw_limits_refuse_at_configuration(limits):
     with pytest.raises(ValidationError):
         policy(max_debits_raw=limits)
+
+
+@pytest.mark.parametrize("unapproved_first", [False, True])
+def test_mixed_markets_refuse_even_when_another_instruction_matches(unapproved_first):
+    raw = evidence()
+    other = copy.deepcopy(raw["actions"][0])
+    other["instruction"]["accounts"] = [{"pubkey": "other-vault"}]
+    raw["actions"].insert(0 if unapproved_first else 1, other)
+    with pytest.raises(ValueError, match="Every selected-protocol instruction"):
+        verify(raw)
+
+
+def test_multiple_selected_market_instructions_and_support_programs_remain_allowed():
+    raw = evidence()
+    raw["actions"].append(copy.deepcopy(raw["actions"][0]))
+    support = copy.deepcopy(raw["actions"][0])
+    support["instruction"].update(program_id="token", accounts=[{"pubkey": "wallet-token"}])
+    raw["actions"].append(support)
+    assert verify(raw, policy(allowed_programs=["protocol", "token"]))["USDC"] == "2000000"


### PR DESCRIPTION
## Operator outcome

Adds an optional `onchain_executor` for Aomi Pipeline execution, verified Aave V3 lending, and shared Solana instruction execution. Jupiter Lend, Kamino Earn and PumpSwap preparation uses protocol-specific recipes in Aomi without adding a Hummingbot connector for each venue. An operator can preview a bounded supply, explicitly execute it, see actual confirmation evidence, and later withdraw through Condor. Completed lending transactions remain in a durable contribution ledger instead of disappearing from exposure history.

Companion UI: hummingbot/condor#232. Gas estimation support: aomi-labs/product-mono#1070. Ready for maintainer review; operational boundaries and evidence are below.

## Implementation

- Connectorless execution: stage/build → simulate → risk check → commit → confirmation. Raw EVM calls and catalog operations remain available; `commit: false` runs without signing.
- Lending mode constructs exact Aave V3 approve/supply or withdraw calldata and verifies chain, wallet, target, amount, approval, recipient and call order before commit.
- Commit retries reuse the original build digest as the idempotency key. Temporary account contention retries the same phase; changed/stale builds do not silently rebuild a reviewed transaction.
- Estimated execution gas is valued in USDT independently of the display pair. A configured ceiling fails closed when the estimate or price is unavailable. The estimate excludes rollup data fees and provider surcharges; it is not a final signing fee cap.
- Creation is persisted before execution starts. Completion-save failures retain the live result for retry. `/executors/lending/positions` combines full durable history with current Base USDC receipt-token balances, deduplicates receipt replays, preserves unknown submissions, and returns errors when history or balances are unavailable.
- Controller net contributions and wallet-wide receipt balances are separate. Deposits/withdrawals are position changes, not trading profit. An optional operator-owned Base USDC policy now validates exact wallet/market/controller grants and contribution limits under a PostgreSQL transaction lock before inserting the durable reservation. Pending supplies consume capacity; only confirmed withdrawals release it. `require_lending_policy` prevents fallback if a grant is removed. This bounds recorded contributions, not all portfolio market exposure; Condor checks the grant, values USDC independently and includes durable contributions in its portfolio risk state.
- Docker clients initialize lazily so an Aomi-only API can start without Docker. Existing bot discovery still reports unavailable Docker.
- Client dependency is pinned to public `aomi-labs/aomi-python` commit `caa72d5225dd60e482835e0341a91293d7549dd3` (v0.1.3). README documents configuration and lifecycle limits.

- Solana preparation binds the registered Aomi app identity and connected wallet. It returns unsigned instructions without staging or committing. The shared executor verifies the reviewed plan hash, complete network-fee evidence, and optional wallet/market/program/debit limits before handoff.
- Solana debit limits cover per-account net wallet debits in a single simulation. They do not constrain intermediate flows, CPI program access, farm exposure, later chain state or unattended execution. Missing or unsupported balance evidence refuses submission.

## Validation

- Latest full local API suite: **1,010 passed, eight integration cases deselected**. Eleven warnings include dependency deprecations and an unawaited fake-client coroutine warning; no failures.

- Previous Aave revision: upstream main `7e86651b69b13b39e0cb3e1afbf080eedd461e8d` merged. then-current full local suite: **928 passed, 8 integration cases deselected**.
- **43 lifecycle/gas tests passed** after the final correction. Duplicate durable creation is rejected before start; upstream completion upserts and performance snapshots are preserved.
- Real PostgreSQL race/restart tests pass under READ COMMITTED and REPEATABLE READ defaults, including required-policy removal. Temporary-contention regressions preserve build digests and idempotency keys.
- Public client v0.1.3: **147 passed, one live skip**, wheel and source distribution built and inspected.
- New Solana preparation/configuration/policy/lifecycle checks: **156 passed**. Additional registration/lending/accounting checks: **62 passed, two database-dependent skips**. Existing dependency warnings remain.

## Solana runtime evidence

All six Condor UI confirmations were independently reconciled with receipts and final positions on a local Solana mirror: Jupiter Lend supply/redeem, Kamino Earn vault supply/withdraw, and PumpSwap direct liquidity add/remove. Reviewed executor hashes, complete fee/balance guards, and final zero positions were checked. Every transaction paid 5,000 lamports in network fees. These used a substituted local test wallet and a locally registered Aomi application fixture; hosted app activation and production Para signing are not demonstrated. The completed V2 recording is linked below.

## Earlier Aave runtime evidence

Current upstream code was exercised through both the Condor UI and typed `create_lending_executor` tool, the authenticated API, durable PostgreSQL policy admission and actual Aomi Pipeline on a Base fork at block 51,161,414.

- Typed granted flow: supplied 5 USDC and withdrew 4.999999 USDC. A 10.000001 USDC request was refused under a 10 USDC per-action limit.
- Recorded UI: supplied 2 USDC and withdrew 1.999999 USDC. All six receipts across these two flows were independently re-read from the live fork with successful status and matching block hash. Remaining approval allowance is zero.
- A 1 USDC preview with a 0.000001 USDT execution-gas budget is refused before wallet submission. Contribution accounting survives completion and is shown separately from shared wallet balances.
- Final accounting correction: simulated gas stays in `custom_info.estimated_gas_quote`; it is never booked as incurred executor fees, including on non-submitting previews. Receipt-derived quote fees are currently unavailable. History navigation follows upstream's `groupBy=ctrlType` contract.

[Exact versions, receipt and balance evidence, reproduction boundaries, and narration script](https://github.com/CeciliaZ030/condor/tree/cecilia/onchain-executor/docs/aomi-demo-evidence/current-upstream). A 148-second walkthrough and individual before/supply/withdraw/refusal/ledger recordings are completed local deliverables; videos are not hosted in the repository. The supply/withdraw footage predates the accounting-only correction and is labeled with its actual source versions.

## Operational boundaries

These are local fork transactions, using a bounded loopback Anvil test signer and a fresh public Kraken gas-conversion adapter. Automatic USDC valuation uses the real Hummingbot Binance endpoint. No model inference or production Para signing is claimed. Eight Para envelope regressions pass, covering empty calldata and explicit fee/nonce validation before HTTP; live signing-provider verification remains a deployment check.

Gas estimates exclude Base data fees and signing-provider surcharges. The allocation policy bounds recorded contributions, not external deposits, interest or the full portfolio. Unknown submissions retain reservations for reconciliation. No realized yield is claimed.

The earlier Aave integration revision merged the upstream baseline described above; current mergeability is reported by GitHub. Supporting backend CI run 34591678160 passed at `2439db38`, including the fresh upstream merge. All three PRs are out of draft. Backend deployment and maintainer merge are separate from this contribution.


[Finished 2:30 V2 video, final narration, fresh receipts and recording notes](https://github.com/CeciliaZ030/condor/tree/69e97fb4223861060bdf48a7937b45dd9fcaecae/docs/aomi-demo-evidence/universal-v2/recording-20260912). Six local transactions were verified, all three positions exited, and a 2 USDC action exceeded its 1.9 USDC limit and was refused before commit. The video is silent with a separate voiceover script; it uses a local Solana mirror and substituted test wallet.


Market-policy review correction: every top-level instruction for the selected protocol must reference the selected market. Mixed-market bundles are rejected regardless of instruction order. 147 targeted policy/configuration/lifecycle tests pass; all six archived demo receipts satisfy the stricter rule. The previous 1,010-test full-suite result predates this correction.


Unsigned preparation handles only explicit HTTP409 operation_in_flight admission refusals with bounded retries; timeouts, 5xx responses and other conflicts are not retried. Exhausted contention returns a sanitized busy response. The correction passed 23 focused tests and a live concurrent-read check. It does not alter transaction submission.
