### PR TITLE
(feat) Add bing_x bulk ticker source for /market-data/tickers

### DIFF
--- a/services/ticker_sources.py
+++ b/services/ticker_sources.py
@@ -230,6 +230,11 @@ TICKER_SPECS: Dict[str, TickerSpec] = {
         symbol="symbol", bid="bidPrice", ask="askPrice", last="lastPrice",
         base_volume="volume", quote_volume="quoteVolume",
     ),
+    "bing_x": TickerSpec(
+        path="/openApi/spot/v1/ticker/24hr", rows=_rows_at("data"),
+        symbol="symbol", bid="bidPrice", ask="askPrice", last="lastPrice",
+        base_volume="volume", quote_volume="quoteVolume",
+    ),
     # The futures 24hr ticker carries no bid/ask, so the price falls back to lastPrice.
     "binance_perpetual": TickerSpec(
         path="v1/ticker/24hr",  # the base URL already carries /fapi/

--- a/test/test_ticker_sources.py
+++ b/test/test_ticker_sources.py
@@ -1,0 +1,45 @@
+import pytest
+
+from services.ticker_sources import fetch_tickers
+
+
+class FakeBingXConnector:
+    def __init__(self):
+        self.calls = []
+
+    async def trading_pair_symbol_map(self):
+        return {"BTC-USDT": "BTC-USDT"}
+
+    async def _api_get(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "code": 0,
+            "data": [
+                {
+                    "symbol": "BTC-USDT",
+                    "bidPrice": "59999.00",
+                    "askPrice": "60001.00",
+                    "lastPrice": "60000.00",
+                    "volume": "12.5",
+                    "quoteVolume": "750000.00",
+                },
+            ],
+        }
+
+    async def _api_post(self, **kwargs):
+        raise AssertionError(f"unexpected POST request: {kwargs}")
+
+
+@pytest.mark.asyncio
+async def test_bing_x_bulk_ticker_request_and_mapping():
+    connector = FakeBingXConnector()
+
+    tickers = await fetch_tickers(connector, "bing_x", raise_on_error=True)
+
+    assert connector.calls == [
+        {"path_url": "/openApi/spot/v1/ticker/24hr", "is_auth_required": False},
+    ]
+    ticker = tickers["BTC-USDT"]
+    assert ticker.price == 60000
+    assert ticker.base_volume == 12.5
+    assert ticker.quote_volume == 750000


### PR DESCRIPTION
## Summary
Adds a bulk `TickerSpec` for the `bing_x` connector so `GET /market-data/tickers?connectors=bing_x` works with a single request instead of reporting "No ticker data" for BingX.

- Endpoint: `GET /openApi/spot/v1/ticker/24hr` (BingX spot REST, base `https://open-api.bingx.com`; the `/openapi` prefix is rejected by BingX for spot market endpoints with error 100400)
- Mapping: rows under `data`; `symbol` → symbol, `bidPrice` → bid, `askPrice` → ask, `lastPrice` → last, `volume` → base volume, `quoteVolume` → quote volume
- Adds a deterministic unit test (`test_bing_x_bulk_ticker_request_and_mapping`) using a fake connector that asserts the request path and the price/volume field mapping

## Testing
- Focused: `pytest test/test_ticker_sources.py::test_bing_x_bulk_ticker_request_and_mapping` — passes
- Live verification against BingX prod: `GET /market-data/tickers?connectors=bing_x&refresh=true` returns 691 trading pairs with `errors: {}`
