### PR TITLE
fix: expose market data provider to executors

### DIFF
--- a/services/trading_service.py
+++ b/services/trading_service.py
@@ -70,6 +70,11 @@ class AccountTradingInterface:
         return self._account_name
 
     @property
+    def market_data_provider(self) -> "MarketDataService":
+        """Return the market data provider used by executors."""
+        return self._market_data_service
+
+    @property
     def connectors(self) -> Dict[str, ConnectorBase]:
         """
         Return connectors for this account from the UnifiedConnectorService.

--- a/test/test_account_trading_interface.py
+++ b/test/test_account_trading_interface.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from services.trading_service import AccountTradingInterface
+
+
+def test_account_trading_interface_exposes_market_data_provider():
+    connector_service = MagicMock()
+    market_data_service = MagicMock()
+
+    trading_interface = AccountTradingInterface(
+        connector_service=connector_service,
+        market_data_service=market_data_service,
+        account_name="test_account",
+    )
+
+    assert trading_interface.market_data_provider is market_data_service


### PR DESCRIPTION
## Summary

Companion change for hummingbot/hummingbot#8453 and hummingbot/hummingbot#8437.

Hummingbot API already uses `MarketDataService` as its pricing source, but executor strategies did not expose that service through the `market_data_provider` interface expected by the core GridExecutor fee-conversion path.

This change exposes the existing `MarketDataService` from `AccountTradingInterface` as `market_data_provider`.

That allows GridExecutor in hummingbot/hummingbot#8453 to resolve third-token fees such as BNB -> USDT through the API market-data pricing pool instead of relying exclusively on the legacy RateOracle singleton.

## Changes

- add `AccountTradingInterface.market_data_provider`
- return the existing `_market_data_service`
- add a focused regression test verifying the same provider instance is exposed

## Tests

`python -m pytest test/test_account_trading_interface.py -q`

1 passed

## Dependency

Depends on hummingbot/hummingbot#8453

Related to hummingbot/hummingbot#8437
